### PR TITLE
move fal-api to internal

### DIFF
--- a/internal/audio/opus_converter.go
+++ b/internal/audio/opus_converter.go
@@ -10,7 +10,7 @@ import (
 // ConvertPCMToOpus converts PCM audio data to Opus format with proper OGG container
 func ConvertPCMToOpus(pcmData []byte) ([]byte, error) {
 	// Create Opus encoder
-	const sampleRate = 48000 // Opus standard sample rate
+	const sampleRate = 24000 // Opus supported sample rate
 	const channels = 1       // Mono audio
 	const bitrate = 64000    // 64kbps bitrate
 
@@ -30,7 +30,7 @@ func ConvertPCMToOpus(pcmData []byte) ([]byte, error) {
 	}
 
 	// Opus frame size must be one of: 120, 240, 480, 960, 1920, 2880 samples
-	// Using 960 samples (20ms at 48kHz) for good quality and reasonable latency
+	// Using 960 samples (40ms at 24kHz) for good quality and reasonable latency
 	const frameSize = 960
 	pcmBuffer := make([]int16, frameSize)
 	var granulePosition uint64

--- a/internal/falapi/client.go
+++ b/internal/falapi/client.go
@@ -1,0 +1,449 @@
+package falapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const (
+	baseURL = "https://queue.fal.run/fal-ai"
+)
+
+type Text2ImageResponse struct {
+	Images []struct {
+		URL         string `json:"url"`
+		ContentType string `json:"content_type"`
+	} `json:"images"`
+}
+
+type QueueResponse struct {
+	Status      string `json:"status"`
+	RequestID   string `json:"request_id"`
+	ResponseURL string `json:"response_url"`
+	StatusURL   string `json:"status_url"`
+	CancelURL   string `json:"cancel_url"`
+	Logs        []struct {
+		Message   string `json:"message"`
+		Level     string `json:"level"`
+		Source    string `json:"source"`
+		Timestamp string `json:"timestamp"`
+	} `json:"logs"`
+	QueuePosition int `json:"queue_position"`
+}
+
+// Client represents a Fal.ai API client
+type Client struct {
+	apiKey     string
+	httpClient *http.Client
+	debug      bool
+}
+
+// NewClient creates a new Fal.ai API client
+func NewClient(apiKey string, debug bool) *Client {
+	return &Client{
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		debug: debug,
+	}
+}
+
+// GenerateImage generates an image from a text prompt
+func (c *Client) GenerateImage(ctx context.Context, prompt string, modelName string, bot interface{}, userNick string) (*ImageResponse, error) {
+	// Create request body
+	reqBody := map[string]interface{}{
+		"prompt": prompt,
+	}
+
+	// Make initial request to queue
+	resp, err := c.makeRequest(ctx, "POST", "/"+modelName, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Parse the initial queue response
+	var queueResp QueueResponse
+	if err := json.NewDecoder(resp.Body).Decode(&queueResp); err != nil {
+		return nil, fmt.Errorf("failed to decode queue response: %v", err)
+	}
+	resp.Body.Close()
+
+	// If we have a queue position, notify the user
+	if queueResp.QueuePosition >= 0 {
+		// Use reflection to call SendPM on the bot
+		botValue := reflect.ValueOf(bot)
+		sendPMMethod := botValue.MethodByName("SendPM")
+		if sendPMMethod.IsValid() {
+			message := "Your image generation request is at the front of the queue."
+			if queueResp.QueuePosition > 0 {
+				message = fmt.Sprintf("Your image generation request is in queue. Position: %d", queueResp.QueuePosition)
+			}
+			sendPMMethod.Call([]reflect.Value{
+				reflect.ValueOf(ctx),
+				reflect.ValueOf(userNick),
+				reflect.ValueOf(message),
+			})
+		}
+	}
+
+	// Create a ticker for polling
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	// Poll status until completion
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			// Get status using status_url
+			statusURL := queueResp.StatusURL + "?logs=1"
+			req, err := http.NewRequestWithContext(ctx, "GET", statusURL, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create status request: %v", err)
+			}
+			req.Header.Set("Authorization", "Key "+c.apiKey)
+
+			statusResp, err := c.httpClient.Do(req)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get status: %v", err)
+			}
+			defer statusResp.Body.Close()
+
+			// Read status response body
+			statusBytes, err := io.ReadAll(statusResp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read status response: %v", err)
+			}
+
+			if c.debug {
+				fmt.Printf("Raw status response: %s\n", string(statusBytes))
+			}
+
+			var status struct {
+				Status      string `json:"status"`
+				RequestID   string `json:"request_id"`
+				ResponseURL string `json:"response_url"`
+				StatusURL   string `json:"status_url"`
+				CancelURL   string `json:"cancel_url"`
+				Logs        []struct {
+					Message   string `json:"message"`
+					Level     string `json:"level"`
+					Source    string `json:"source"`
+					Timestamp string `json:"timestamp"`
+				} `json:"logs"`
+				QueuePosition int `json:"queue_position"`
+			}
+
+			if err := json.Unmarshal(statusBytes, &status); err != nil {
+				return nil, fmt.Errorf("failed to parse status response: %v", err)
+			}
+
+			if c.debug {
+				fmt.Printf("Status Response: %+v\n", status)
+			}
+
+			switch status.Status {
+			case "IN_QUEUE":
+				if status.QueuePosition > 0 {
+					// Send queue position update to user
+					botValue := reflect.ValueOf(bot)
+					sendPMMethod := botValue.MethodByName("SendPM")
+					if sendPMMethod.IsValid() {
+						ctxValue := reflect.ValueOf(ctx)
+						userNickValue := reflect.ValueOf(userNick)
+						messageValue := reflect.ValueOf(fmt.Sprintf("Your image generation request is in queue, position: %d", status.QueuePosition))
+
+						args := []reflect.Value{ctxValue, userNickValue, messageValue}
+						sendPMMethod.Call(args)
+					}
+				}
+			case "IN_PROGRESS":
+				// Send progress update to user if we have logs
+				if len(status.Logs) > 0 {
+					// Get the latest log entry
+					latestLog := status.Logs[len(status.Logs)-1]
+
+					// Use reflection to call SendPM on the bot
+					botValue := reflect.ValueOf(bot)
+					sendPMMethod := botValue.MethodByName("SendPM")
+					if sendPMMethod.IsValid() {
+						sendPMMethod.Call([]reflect.Value{
+							reflect.ValueOf(ctx),
+							reflect.ValueOf(userNick),
+							reflect.ValueOf(fmt.Sprintf("Progress: %s", latestLog.Message)),
+						})
+					}
+				}
+
+				if len(status.Logs) > 0 {
+					for _, log := range status.Logs {
+						fmt.Printf("Progress: %s\n", log.Message)
+					}
+				}
+			case "COMPLETED":
+				// Get final response using the base request URL (without /status)
+				responseURL := strings.TrimSuffix(queueResp.ResponseURL, "/status")
+				req, err := http.NewRequestWithContext(ctx, "GET", responseURL, nil)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create final response request: %v", err)
+				}
+				req.Header.Set("Authorization", "Key "+c.apiKey)
+
+				finalResp, err := c.httpClient.Do(req)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get final response: %v", err)
+				}
+				defer finalResp.Body.Close()
+
+				// Read final response body
+				finalBytes, err := io.ReadAll(finalResp.Body)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read final response: %v", err)
+				}
+
+				if c.debug {
+					fmt.Printf("Raw final response: %s\n", string(finalBytes))
+				}
+
+				var finalResponse struct {
+					Images []struct {
+						URL         string `json:"url"`
+						Width       int    `json:"width"`
+						Height      int    `json:"height"`
+						ContentType string `json:"content_type"`
+					} `json:"images"`
+					Timings struct {
+						Inference float64 `json:"inference"`
+					} `json:"timings"`
+					Seed            json.Number `json:"seed"`
+					HasNSFWConcepts []bool      `json:"has_nsfw_concepts"`
+					Prompt          string      `json:"prompt"`
+				}
+
+				if err := json.Unmarshal(finalBytes, &finalResponse); err != nil {
+					return nil, fmt.Errorf("failed to parse final response: %v", err)
+				}
+
+				if c.debug {
+					fmt.Printf("Final Response: %+v\n", finalResponse)
+				}
+
+				if len(finalResponse.Images) == 0 {
+					return nil, fmt.Errorf("no images in response")
+				}
+
+				// Download the image from the URL
+				imgResp, err := http.Get(finalResponse.Images[0].URL)
+				if err != nil {
+					return nil, fmt.Errorf("failed to download image: %v", err)
+				}
+				defer imgResp.Body.Close()
+
+				// Read the image data
+				imgData, err := io.ReadAll(imgResp.Body)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read image data: %v", err)
+				}
+
+				// Encode the image as base64
+				base64Image := base64.StdEncoding.EncodeToString(imgData)
+
+				// Create the PM message format
+				message := fmt.Sprintf("--embed[alt=%s,type=%s,data=%s]--",
+					url.QueryEscape(prompt),
+					finalResponse.Images[0].ContentType,
+					base64Image)
+
+				if c.debug {
+					fmt.Printf("PM Message: %s\n", message)
+				}
+
+				// Create an ImageResponse to return
+				imageResp := &ImageResponse{
+					Images: []struct {
+						URL         string `json:"url"`
+						Width       int    `json:"width"`
+						Height      int    `json:"height"`
+						ContentType string `json:"content_type"`
+					}{
+						{
+							URL:         finalResponse.Images[0].URL,
+							Width:       finalResponse.Images[0].Width,
+							Height:      finalResponse.Images[0].Height,
+							ContentType: finalResponse.Images[0].ContentType,
+						},
+					},
+					Timings: struct {
+						Inference float64 `json:"inference"`
+					}{
+						Inference: finalResponse.Timings.Inference,
+					},
+					Seed:            finalResponse.Seed,
+					HasNSFWConcepts: finalResponse.HasNSFWConcepts,
+					Prompt:          finalResponse.Prompt,
+				}
+
+				return imageResp, nil
+			case "FAILED":
+				// Send failure message to user
+				botValue := reflect.ValueOf(bot)
+				sendPMMethod := botValue.MethodByName("SendPM")
+				if sendPMMethod.IsValid() {
+					ctxValue := reflect.ValueOf(ctx)
+					userNickValue := reflect.ValueOf(userNick)
+					messageValue := reflect.ValueOf("Your image generation request failed.")
+
+					args := []reflect.Value{ctxValue, userNickValue, messageValue}
+					sendPMMethod.Call(args)
+				}
+				return nil, fmt.Errorf("request failed")
+			}
+		}
+	}
+}
+
+// GenerateSpeech generates speech from text
+func (c *Client) GenerateSpeech(ctx context.Context, text string, voiceID string) (*AudioResponse, error) {
+	// Create request body
+	reqBody := map[string]interface{}{
+		"text":     text,
+		"voice_id": voiceID,
+	}
+
+	// Make request
+	resp, err := c.makeRequest(ctx, "POST", "/flux/text2speech", reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check if job is in progress
+	if resp.StatusCode == http.StatusAccepted {
+		// Parse the response to get the status URL
+		var statusResp struct {
+			StatusURL string `json:"status_url"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&statusResp); err != nil {
+			return nil, fmt.Errorf("failed to parse status response: %v", err)
+		}
+
+		// Poll the status URL until the job is complete
+		for {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+				// Wait a bit before polling again
+				time.Sleep(2 * time.Second)
+
+				// Make request to status URL
+				statusResp, err := http.Get(statusResp.StatusURL)
+				if err != nil {
+					return nil, fmt.Errorf("failed to check status: %v", err)
+				}
+				defer statusResp.Body.Close()
+
+				// If status is 200, job is complete
+				if statusResp.StatusCode == http.StatusOK {
+					var audioResp AudioResponse
+					if err := json.NewDecoder(statusResp.Body).Decode(&audioResp); err != nil {
+						return nil, fmt.Errorf("failed to parse audio response: %v", err)
+					}
+					return &audioResp, nil
+				}
+
+				// If status is not 202, something went wrong
+				if statusResp.StatusCode != http.StatusAccepted {
+					return nil, fmt.Errorf("unexpected status code: %d", statusResp.StatusCode)
+				}
+			}
+		}
+	}
+
+	// If we get here, the response was not a 202
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed with status %d", resp.StatusCode)
+	}
+
+	// Parse response
+	var audioResp AudioResponse
+	if err := json.NewDecoder(resp.Body).Decode(&audioResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	return &audioResp, nil
+}
+
+// makeRequest makes a request to the Fal.ai API
+func (c *Client) makeRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
+	// Create request
+	var reqBody []byte
+	var err error
+	if body != nil {
+		reqBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request: %v", err)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, baseURL+path, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Key "+c.apiKey)
+
+	// Make request
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+
+	return resp, nil
+}
+
+func (c *Client) GetModels(commandType string) (map[string]Model, error) {
+	switch commandType {
+	case "text2image":
+		return Text2ImageModels, nil
+	case "text2speech":
+		return Text2SpeechModels, nil
+	default:
+		return nil, fmt.Errorf("unknown command type: %s", commandType)
+	}
+}
+
+func (c *Client) GetCurrentModel(commandType string) (Model, error) {
+	modelName, exists := GetDefaultModel(commandType)
+	if !exists {
+		return Model{}, fmt.Errorf("no default model found for command type: %s", commandType)
+	}
+
+	model, exists := GetModel(modelName, commandType)
+	if !exists {
+		return Model{}, fmt.Errorf("model not found: %s", modelName)
+	}
+
+	return model, nil
+}
+
+func (c *Client) SetCurrentModel(commandType, modelName string) error {
+	if !SetDefaultModel(commandType, modelName) {
+		return fmt.Errorf("failed to set default model %s for command type %s", modelName, commandType)
+	}
+	return nil
+}

--- a/internal/falapi/client.go
+++ b/internal/falapi/client.go
@@ -315,75 +315,226 @@ func (c *Client) GenerateImage(ctx context.Context, prompt string, modelName str
 }
 
 // GenerateSpeech generates speech from text
-func (c *Client) GenerateSpeech(ctx context.Context, text string, voiceID string) (*AudioResponse, error) {
+func (c *Client) GenerateSpeech(ctx context.Context, text string, voiceID string, bot interface{}, userNick string) (*AudioResponse, error) {
 	// Create request body
 	reqBody := map[string]interface{}{
 		"text":     text,
 		"voice_id": voiceID,
+		"audio_setting": map[string]interface{}{
+			"format":      "pcm",
+			"sample_rate": 24000,
+			"channel":     1,
+		},
 	}
 
-	// Make request
-	resp, err := c.makeRequest(ctx, "POST", "/flux/text2speech", reqBody)
+	// Make initial request to queue with the correct URL format
+	// Format: https://queue.fal.run/fal-ai/minimax-tts/text-to-speech
+	resp, err := c.makeRequest(ctx, "POST", "/minimax-tts/text-to-speech", reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %v", err)
+		return nil, fmt.Errorf("failed to make request: %v", err)
 	}
 	defer resp.Body.Close()
 
-	// Check if job is in progress
-	if resp.StatusCode == http.StatusAccepted {
-		// Parse the response to get the status URL
-		var statusResp struct {
-			StatusURL string `json:"status_url"`
+	// Parse the initial queue response
+	var queueResp QueueResponse
+	if err := json.NewDecoder(resp.Body).Decode(&queueResp); err != nil {
+		return nil, fmt.Errorf("failed to decode queue response: %v", err)
+	}
+	resp.Body.Close()
+
+	// If we have a queue position, notify the user
+	if queueResp.QueuePosition >= 0 {
+		// Use reflection to call SendPM on the bot
+		botValue := reflect.ValueOf(bot)
+		sendPMMethod := botValue.MethodByName("SendPM")
+		if sendPMMethod.IsValid() {
+			message := "Your speech generation request is at the front of the queue."
+			if queueResp.QueuePosition > 0 {
+				message = fmt.Sprintf("Your speech generation request is in queue. Position: %d", queueResp.QueuePosition)
+			}
+			sendPMMethod.Call([]reflect.Value{
+				reflect.ValueOf(ctx),
+				reflect.ValueOf(userNick),
+				reflect.ValueOf(message),
+			})
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&statusResp); err != nil {
-			return nil, fmt.Errorf("failed to parse status response: %v", err)
-		}
+	}
 
-		// Poll the status URL until the job is complete
-		for {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			default:
-				// Wait a bit before polling again
-				time.Sleep(2 * time.Second)
+	// Create a ticker for polling
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
 
-				// Make request to status URL
-				statusResp, err := http.Get(statusResp.StatusURL)
-				if err != nil {
-					return nil, fmt.Errorf("failed to check status: %v", err)
-				}
-				defer statusResp.Body.Close()
+	// Poll status until completion
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			// Get status using status_url
+			statusURL := queueResp.StatusURL + "?logs=1"
+			req, err := http.NewRequestWithContext(ctx, "GET", statusURL, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create status request: %v", err)
+			}
+			req.Header.Set("Authorization", "Key "+c.apiKey)
 
-				// If status is 200, job is complete
-				if statusResp.StatusCode == http.StatusOK {
-					var audioResp AudioResponse
-					if err := json.NewDecoder(statusResp.Body).Decode(&audioResp); err != nil {
-						return nil, fmt.Errorf("failed to parse audio response: %v", err)
+			statusResp, err := c.httpClient.Do(req)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get status: %v", err)
+			}
+			defer statusResp.Body.Close()
+
+			// Read status response body
+			statusBytes, err := io.ReadAll(statusResp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read status response: %v", err)
+			}
+
+			if c.debug {
+				fmt.Printf("Raw status response: %s\n", string(statusBytes))
+			}
+
+			var status struct {
+				Status      string `json:"status"`
+				RequestID   string `json:"request_id"`
+				ResponseURL string `json:"response_url"`
+				StatusURL   string `json:"status_url"`
+				CancelURL   string `json:"cancel_url"`
+				Logs        []struct {
+					Message   string `json:"message"`
+					Level     string `json:"level"`
+					Source    string `json:"source"`
+					Timestamp string `json:"timestamp"`
+				} `json:"logs"`
+				QueuePosition int `json:"queue_position"`
+			}
+
+			if err := json.Unmarshal(statusBytes, &status); err != nil {
+				return nil, fmt.Errorf("failed to parse status response: %v", err)
+			}
+
+			if c.debug {
+				fmt.Printf("Status Response: %+v\n", status)
+			}
+
+			switch status.Status {
+			case "IN_QUEUE":
+				if status.QueuePosition > 0 {
+					// Send queue position update to user
+					botValue := reflect.ValueOf(bot)
+					sendPMMethod := botValue.MethodByName("SendPM")
+					if sendPMMethod.IsValid() {
+						sendPMMethod.Call([]reflect.Value{
+							reflect.ValueOf(ctx),
+							reflect.ValueOf(userNick),
+							reflect.ValueOf(fmt.Sprintf("Your speech generation request is in queue, position: %d", status.QueuePosition)),
+						})
 					}
-					return &audioResp, nil
+				}
+			case "IN_PROGRESS":
+				// Send progress update to user if we have logs
+				if len(status.Logs) > 0 {
+					// Get the latest log entry
+					latestLog := status.Logs[len(status.Logs)-1]
+
+					// Use reflection to call SendPM on the bot
+					botValue := reflect.ValueOf(bot)
+					sendPMMethod := botValue.MethodByName("SendPM")
+					if sendPMMethod.IsValid() {
+						sendPMMethod.Call([]reflect.Value{
+							reflect.ValueOf(ctx),
+							reflect.ValueOf(userNick),
+							reflect.ValueOf(fmt.Sprintf("Progress: %s", latestLog.Message)),
+						})
+					}
+				}
+			case "COMPLETED":
+				// Get final response using the correct URL format for text2speech
+				// Format: https://queue.fal.run/fal-ai/minimax-tts/requests/{request_id}
+				responseURL := fmt.Sprintf("https://queue.fal.run/fal-ai/minimax-tts/requests/%s", status.RequestID)
+				req, err := http.NewRequestWithContext(ctx, "GET", responseURL, nil)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create final response request: %v", err)
+				}
+				req.Header.Set("Authorization", "Key "+c.apiKey)
+
+				finalResp, err := c.httpClient.Do(req)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get final response: %v", err)
+				}
+				defer finalResp.Body.Close()
+
+				// Read final response body
+				finalBytes, err := io.ReadAll(finalResp.Body)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read final response: %v", err)
 				}
 
-				// If status is not 202, something went wrong
-				if statusResp.StatusCode != http.StatusAccepted {
-					return nil, fmt.Errorf("unexpected status code: %d", statusResp.StatusCode)
+				if c.debug {
+					fmt.Printf("Raw final response: %s\n", string(finalBytes))
 				}
+
+				// Check if the response is an error
+				if finalResp.StatusCode != http.StatusOK {
+					return nil, fmt.Errorf("request failed with status %d: %s", finalResp.StatusCode, string(finalBytes))
+				}
+
+				// Parse the response to get the audio URL
+				var responseData struct {
+					Audio struct {
+						URL         string `json:"url"`
+						ContentType string `json:"content_type"`
+						FileName    string `json:"file_name"`
+						FileSize    int    `json:"file_size"`
+					} `json:"audio"`
+					DurationMs int `json:"duration_ms"`
+				}
+
+				if err := json.Unmarshal(finalBytes, &responseData); err != nil {
+					return nil, fmt.Errorf("failed to parse final response: %v", err)
+				}
+
+				if c.debug {
+					fmt.Printf("Parsed Response: %+v\n", responseData)
+				}
+
+				// Check if we have a valid audio URL
+				if responseData.Audio.URL == "" {
+					return nil, fmt.Errorf("no audio URL in response")
+				}
+
+				// Create an AudioResponse to return
+				audioResp := &AudioResponse{
+					Audio: struct {
+						URL         string `json:"url"`
+						ContentType string `json:"content_type"`
+						FileName    string `json:"file_name"`
+						FileSize    int    `json:"file_size"`
+					}{
+						URL:         responseData.Audio.URL,
+						ContentType: responseData.Audio.ContentType,
+						FileName:    responseData.Audio.FileName,
+						FileSize:    responseData.Audio.FileSize,
+					},
+					DurationMs: responseData.DurationMs,
+				}
+
+				return audioResp, nil
+			case "FAILED":
+				// Send failure message to user
+				botValue := reflect.ValueOf(bot)
+				sendPMMethod := botValue.MethodByName("SendPM")
+				if sendPMMethod.IsValid() {
+					sendPMMethod.Call([]reflect.Value{
+						reflect.ValueOf(ctx),
+						reflect.ValueOf(userNick),
+						reflect.ValueOf("Your speech generation request failed."),
+					})
+				}
+				return nil, fmt.Errorf("request failed")
 			}
 		}
 	}
-
-	// If we get here, the response was not a 202
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request failed with status %d", resp.StatusCode)
-	}
-
-	// Parse response
-	var audioResp AudioResponse
-	if err := json.NewDecoder(resp.Body).Decode(&audioResp); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %v", err)
-	}
-
-	return &audioResp, nil
 }
 
 // makeRequest makes a request to the Fal.ai API

--- a/internal/falapi/models.go
+++ b/internal/falapi/models.go
@@ -1,0 +1,85 @@
+package falapi
+
+// Text2ImageModels contains all available text-to-image models
+var Text2ImageModels = map[string]Model{
+	"fast-sdxl": {
+		Name:        "fast-sdxl",
+		Description: "Fast model for generating images quickly.",
+		Price:       0.02,
+	},
+	"hidream-i1-full": {
+		Name:        "hidream-i1-full",
+		Description: "High-quality model for detailed images.",
+		Price:       0.10,
+	},
+	"hidream-i1-dev": {
+		Name:        "hidream-i1-dev",
+		Description: "Development version of the HiDream model.",
+		Price:       0.06,
+	},
+	"hidream-i1-fast": {
+		Name:        "hidream-i1-fast",
+		Description: "Faster version of the HiDream model.",
+		Price:       0.03,
+	},
+	"flux-pro/v1.1": {
+		Name:        "flux-pro/v1.1",
+		Description: "Professional model for high-end image generation.",
+		Price:       0.08,
+	},
+	"flux-pro/v1.1-ultra": {
+		Name:        "flux-pro/v1.1-ultra",
+		Description: "Ultra version of the professional model.",
+		Price:       0.12,
+	},
+	"flux/schnell": {
+		Name:        "flux/schnell",
+		Description: "Quick model for rapid image generation.",
+		Price:       0.02,
+	},
+}
+
+// Text2SpeechModels contains all available text-to-speech models
+var Text2SpeechModels = map[string]Model{
+	"minimax-tts/text-to-speech": {
+		Name:        "minimax-tts/text-to-speech",
+		Description: "Text-to-speech model for converting text to audio. $0.10 per 1000 characters.",
+		Price:       0.10,
+	},
+}
+
+// DefaultModels contains the default model for each command type
+var DefaultModels = map[string]string{
+	"text2image":  "fast-sdxl",                  // Default model for text2image
+	"text2speech": "minimax-tts/text-to-speech", // Default model for text2speech
+}
+
+// GetModel returns the model configuration for a given model name and command type
+func GetModel(modelName, commandType string) (Model, bool) {
+	var models map[string]Model
+	switch commandType {
+	case "text2image":
+		models = Text2ImageModels
+	case "text2speech":
+		models = Text2SpeechModels
+	default:
+		return Model{}, false
+	}
+	model, exists := models[modelName]
+	return model, exists
+}
+
+// GetDefaultModel returns the default model name for a given command type
+func GetDefaultModel(commandType string) (string, bool) {
+	model, exists := DefaultModels[commandType]
+	return model, exists
+}
+
+// SetDefaultModel sets the default model for a given command type
+func SetDefaultModel(commandType, modelName string) bool {
+	if _, exists := GetModel(modelName, commandType); !exists {
+		return false
+	}
+	DefaultModels[commandType] = modelName
+	return true
+}

--- a/internal/falapi/types.go
+++ b/internal/falapi/types.go
@@ -1,0 +1,67 @@
+package falapi
+
+import "encoding/json"
+
+// Model represents a Fal.ai model configuration
+type Model struct {
+	Name        string  // Name of the model
+	Description string  // Description of the model
+	Price       float64 // Price per picture in USD
+}
+
+// FalResponse represents the response from Fal.ai API
+type FalResponse struct {
+	Status        string `json:"status,omitempty"`
+	RequestID     string `json:"request_id,omitempty"`
+	ResponseURL   string `json:"response_url,omitempty"`
+	StatusURL     string `json:"status_url,omitempty"`
+	CancelURL     string `json:"cancel_url,omitempty"`
+	QueuePosition int    `json:"queue_position,omitempty"`
+	Logs          []struct {
+		Message   string `json:"message"`
+		Level     string `json:"level"`
+		Source    string `json:"source"`
+		Timestamp string `json:"timestamp"`
+	} `json:"logs,omitempty"`
+	Response struct {
+		Images []struct {
+			URL         string `json:"url"`
+			Width       int    `json:"width"`
+			Height      int    `json:"height"`
+			ContentType string `json:"content_type"`
+		} `json:"images"`
+	} `json:"response,omitempty"`
+}
+
+// ImageResponse represents the final image generation response
+type ImageResponse struct {
+	Images []struct {
+		URL         string `json:"url"`
+		Width       int    `json:"width"`
+		Height      int    `json:"height"`
+		ContentType string `json:"content_type"`
+	} `json:"images"`
+	Timings struct {
+		Inference float64 `json:"inference"`
+	} `json:"timings"`
+	Seed            json.Number `json:"seed"`
+	HasNSFWConcepts []bool      `json:"has_nsfw_concepts"`
+	Prompt          string      `json:"prompt"`
+}
+
+// AudioResponse represents the final audio generation response
+type AudioResponse struct {
+	Audio struct {
+		URL         string `json:"url"`
+		ContentType string `json:"content_type"`
+		FileName    string `json:"file_name"`
+		FileSize    int    `json:"file_size"`
+	} `json:"audio"`
+	DurationMs int `json:"duration_ms"`
+}
+
+// StatusResponse represents the status check response
+type StatusResponse struct {
+	Status        string `json:"status"`
+	QueuePosition int    `json:"queue_position,omitempty"`
+}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -28,6 +27,7 @@ import (
 	"github.com/companyzero/bisonrelay/zkidentity"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/karamble/braibot/internal/audio"
+	"github.com/karamble/braibot/internal/falapi"
 	kit "github.com/vctt94/bisonbotkit"
 	"github.com/vctt94/bisonbotkit/config"
 	"github.com/vctt94/bisonbotkit/logging"
@@ -41,95 +41,11 @@ var (
 	dbManager *DBManager // Database manager for user balances
 )
 
-// Define a struct for the model details
-type Model struct {
-	Name        string  // Name of the model
-	Description string  // Description of the model
-	Price       float64 // Price per picture in USD
-}
-
-// Separate model maps for each command type
-var text2imageModels = map[string]Model{
-	"fast-sdxl": {
-		Name:        "fast-sdxl",
-		Description: "Fast model for generating images quickly.",
-		Price:       0.02,
-	},
-	"hidream-i1-full": {
-		Name:        "hidream-i1-full",
-		Description: "High-quality model for detailed images.",
-		Price:       0.10,
-	},
-	"hidream-i1-dev": {
-		Name:        "hidream-i1-dev",
-		Description: "Development version of the HiDream model.",
-		Price:       0.06,
-	},
-	"hidream-i1-fast": {
-		Name:        "hidream-i1-fast",
-		Description: "Faster version of the HiDream model.",
-		Price:       0.03,
-	},
-	"flux-pro/v1.1": {
-		Name:        "flux-pro/v1.1",
-		Description: "Professional model for high-end image generation.",
-		Price:       0.08,
-	},
-	"flux-pro/v1.1-ultra": {
-		Name:        "flux-pro/v1.1-ultra",
-		Description: "Ultra version of the professional model.",
-		Price:       0.12,
-	},
-	"flux/schnell": {
-		Name:        "flux/schnell",
-		Description: "Quick model for rapid image generation.",
-		Price:       0.02,
-	},
-}
-
-var text2speechModels = map[string]Model{
-	"minimax-tts/text-to-speech": {
-		Name:        "minimax-tts/text-to-speech",
-		Description: "Text-to-speech model for converting text to audio. $0.10 per 1000 characters.",
-		Price:       0.10,
-	},
-}
-
-// Map to hold the current model for each command
-var currentModels = map[string]string{
-	"text2image":  "fast-sdxl",                  // Default model for text2image
-	"text2speech": "minimax-tts/text-to-speech", // Default model for text2speech
-}
-
 // Command represents a bot command
 type Command struct {
 	Name        string
 	Description string
 	Handler     func(ctx context.Context, bot *kit.Bot, cfg *config.BotConfig, pm types.ReceivedPM, args []string) error
-}
-
-// FalResponse represents the response from Fal.ai API
-type FalResponse struct {
-	Status        string `json:"status,omitempty"`
-	RequestID     string `json:"request_id,omitempty"`
-	ResponseURL   string `json:"response_url,omitempty"`
-	StatusURL     string `json:"status_url,omitempty"`
-	CancelURL     string `json:"cancel_url,omitempty"`
-	QueuePosition int    `json:"queue_position,omitempty"`
-	Logs          []struct {
-		Message   string `json:"message"`
-		Level     string `json:"level"`
-		Source    string `json:"source"`
-		Timestamp string `json:"timestamp"`
-	} `json:"logs,omitempty"`
-	Response struct {
-		Images []struct {
-			URL         string `json:"url"`
-			Width       int    `json:"width"`
-			Height      int    `json:"height"`
-			ContentType string `json:"content_type"`
-		} `json:"images"`
-	} `json:"response,omitempty"`
 }
 
 // Available commands
@@ -311,14 +227,14 @@ func init() {
 				commandName := strings.ToLower(args[0])
 
 				var modelList string
-				var models map[string]Model
+				var models map[string]falapi.Model
 
 				switch commandName {
 				case "text2image":
-					models = text2imageModels
+					models = falapi.Text2ImageModels
 					modelList = "Available models for text2image:\n| Model | Description | Price |\n| ----- | ----------- | ----- |\n"
 				case "text2speech":
-					models = text2speechModels
+					models = falapi.Text2SpeechModels
 					modelList = "Available models for text2speech:\n| Model | Description | Price |\n| ----- | ----------- | ----- |\n"
 				default:
 					return bot.SendPM(ctx, pm.Nick, "Invalid command. Use 'text2image' or 'text2speech'.")
@@ -347,18 +263,18 @@ func init() {
 				}
 
 				// Check if the model is valid for the specific command
-				var models map[string]Model
+				var models map[string]falapi.Model
 				switch commandName {
 				case "text2image":
-					models = text2imageModels
+					models = falapi.Text2ImageModels
 				case "text2speech":
-					models = text2speechModels
+					models = falapi.Text2SpeechModels
 				default:
 					return bot.SendPM(ctx, pm.Nick, "Invalid command. Use 'text2image' or 'text2speech'.")
 				}
 
 				if _, exists := models[modelName]; exists {
-					currentModels[commandName] = modelName
+					falapi.SetDefaultModel(commandName, modelName)
 					return bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Model for %s set to: %s", commandName, modelName))
 				}
 
@@ -375,185 +291,61 @@ func init() {
 
 				prompt := strings.Join(args, " ")
 
-				// Prepare the request
-				requestBody, err := json.Marshal(map[string]interface{}{
-					"prompt": prompt,
-				})
+				// Create Fal.ai client
+				client := falapi.NewClient(cfg.ExtraConfig["falapikey"], debug)
+
+				// Get model configuration
+				modelName, exists := falapi.GetDefaultModel("text2image")
+				if !exists {
+					return fmt.Errorf("no default model found for text2image")
+				}
+				model, exists := falapi.GetModel(modelName, "text2image")
+				if !exists {
+					return fmt.Errorf("model not found: %s", modelName)
+				}
+
+				// Generate image
+				imageResp, err := client.GenerateImage(ctx, prompt, model.Name, bot, pm.Nick)
 				if err != nil {
 					return err
 				}
 
-				// Use the current model for text2image
-				modelToUse := currentModels["text2image"]
-
-				// Create HTTP request for initial call
-				req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("https://queue.fal.run/fal-ai/%s", modelToUse), bytes.NewBuffer(requestBody))
-				if err != nil {
-					return err
-				}
-
-				// Set headers
-				req.Header.Set("Content-Type", "application/json")
-				req.Header.Set("Authorization", "Key "+cfg.ExtraConfig["falapikey"])
-
-				// Send request
-				client := &http.Client{}
-				resp, err := client.Do(req)
-				if err != nil {
-					return err
-				}
-				defer resp.Body.Close()
-
-				// Read response
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					return err
-				}
-
-				// Parse initial response
-				var initialResp FalResponse
-				if err := json.Unmarshal(body, &initialResp); err != nil {
-					return err
-				}
-
-				// Poll until completion
-				ticker := time.NewTicker(500 * time.Millisecond)
-				defer ticker.Stop()
-
-				for {
-					select {
-					case <-ctx.Done():
-						return ctx.Err()
-					case <-ticker.C:
-						// Check status with logs enabled
-						statusReq, err := http.NewRequestWithContext(ctx, "GET", initialResp.StatusURL+"?logs=1", nil)
-						if err != nil {
-							return err
-						}
-						statusReq.Header.Set("Authorization", "Key "+cfg.ExtraConfig["falapikey"])
-
-						statusResp, err := client.Do(statusReq)
-						if err != nil {
-							return err
-						}
-
-						statusBody, err := io.ReadAll(statusResp.Body)
-						statusResp.Body.Close()
-						if err != nil {
-							return err
-						}
-
-						var statusResponse FalResponse
-						if err := json.Unmarshal(statusBody, &statusResponse); err != nil {
-							return err
-						}
-
-						switch statusResponse.Status {
-						case "IN_QUEUE":
-							// Send queue position update
-							bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Your request is in queue. Position: %d", statusResponse.QueuePosition))
-							continue
-						case "IN_PROGRESS":
-							// Log progress if available
-							if len(statusResponse.Logs) > 0 {
-								bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Processing: %s", statusResponse.Logs[len(statusResponse.Logs)-1].Message))
-							}
-							continue
-						case "COMPLETED":
-							// Fetch final response
-							finalReq, err := http.NewRequestWithContext(ctx, "GET", initialResp.ResponseURL, nil)
-							if err != nil {
-								return err
-							}
-							finalReq.Header.Set("Authorization", "Key "+cfg.ExtraConfig["falapikey"])
-
-							finalResp, err := client.Do(finalReq)
-							if err != nil {
-								return err
-							}
-							defer finalResp.Body.Close()
-
-							// Check the status code
-							if finalResp.StatusCode != http.StatusOK {
-								body, _ := io.ReadAll(finalResp.Body) // Read the body for logging
-								return bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Error fetching final response: %s. Body: %s", finalResp.Status, string(body)))
-							}
-
-							finalBody, err := io.ReadAll(finalResp.Body)
-							if err != nil {
-								return err
-							}
-
-							// Debug output
-							if debug {
-								fmt.Printf("Final Response Body: %s\n", string(finalBody))
-							}
-
-							// Unmarshal the final response
-							var finalResponse struct {
-								Images []struct {
-									URL         string `json:"url"`
-									Width       int    `json:"width"`
-									Height      int    `json:"height"`
-									ContentType string `json:"content_type"`
-								} `json:"images"`
-								Timings struct {
-									Inference float64 `json:"inference"`
-								} `json:"timings"`
-								Seed            json.Number `json:"seed"`
-								HasNSFWConcepts []bool      `json:"has_nsfw_concepts"`
-								Prompt          string      `json:"prompt"`
-							}
-							if err := json.Unmarshal(finalBody, &finalResponse); err != nil {
-								return err
-							}
-
-							// Assuming the first image is the one we want to send
-							if len(finalResponse.Images) > 0 {
-								imageURL := finalResponse.Images[0].URL
-								// Fetch the image data
-								imgResp, err := http.Get(imageURL)
-								if err != nil {
-									return err
-								}
-								defer imgResp.Body.Close()
-
-								imgData, err := io.ReadAll(imgResp.Body)
-								if err != nil {
-									return err
-								}
-
-								// Encode the image data to base64
-								encodedImage := base64.StdEncoding.EncodeToString(imgData)
-
-								// Determine the image type from ContentType
-								var imageType string
-								switch finalResponse.Images[0].ContentType {
-								case "image/jpeg":
-									imageType = "image/jpeg"
-								case "image/png":
-									imageType = "image/png"
-								case "image/webp":
-									imageType = "image/webp"
-								default:
-									imageType = "image/jpeg" // Fallback to jpeg if unknown
-								}
-
-								// Create the message with embedded image, using the user's prompt as the alt text
-								message := fmt.Sprintf("--embed[alt=%s,type=%s,data=%s]--", url.QueryEscape(prompt), imageType, encodedImage)
-								return bot.SendPM(ctx, pm.Nick, message)
-							} else {
-								return bot.SendPM(ctx, pm.Nick, "No images were generated.")
-							}
-						case "FAILED":
-							// Send the complete raw response body as PM
-							responseMessage := fmt.Sprintf("Failed to generate image. Complete response: %s", string(statusBody))
-							return bot.SendPM(ctx, pm.Nick, responseMessage)
-						default:
-							// Still processing, continue polling
-							continue
-						}
+				// Assuming the first image is the one we want to send
+				if len(imageResp.Images) > 0 {
+					imageURL := imageResp.Images[0].URL
+					// Fetch the image data
+					imgResp, err := http.Get(imageURL)
+					if err != nil {
+						return err
 					}
+					defer imgResp.Body.Close()
+
+					imgData, err := io.ReadAll(imgResp.Body)
+					if err != nil {
+						return err
+					}
+
+					// Encode the image data to base64
+					encodedImage := base64.StdEncoding.EncodeToString(imgData)
+
+					// Determine the image type from ContentType
+					var imageType string
+					switch imageResp.Images[0].ContentType {
+					case "image/jpeg":
+						imageType = "image/jpeg"
+					case "image/png":
+						imageType = "image/png"
+					case "image/webp":
+						imageType = "image/webp"
+					default:
+						imageType = "image/jpeg" // Fallback to jpeg if unknown
+					}
+
+					// Create the message with embedded image, using the user's prompt as the alt text
+					message := fmt.Sprintf("--embed[alt=%s,type=%s,data=%s]--", url.QueryEscape(prompt), imageType, encodedImage)
+					return bot.SendPM(ctx, pm.Nick, message)
+				} else {
+					return bot.SendPM(ctx, pm.Nick, "No images were generated.")
 				}
 			},
 		},
@@ -669,209 +461,66 @@ func init() {
 					text = strings.Join(args, " ")
 				}
 
-				// Prepare the request
-				requestBody, err := json.Marshal(map[string]interface{}{
-					"text": text,
-					"voice_setting": map[string]interface{}{
-						"voice_id": voiceID,
-					},
-					"audio_setting": map[string]interface{}{
-						"format":      "pcm",
-						"sample_rate": 44100, // Highest supported sample rate (integer)
-						"channel":     1,     // Mono audio (integer)
-					},
-				})
-				if err != nil {
-					return err
+				// Create Fal.ai client
+				client := falapi.NewClient(cfg.ExtraConfig["falapikey"], debug)
+
+				// Get model configuration
+				modelName, exists := falapi.GetDefaultModel("text2speech")
+				if !exists {
+					return fmt.Errorf("no default model found for text2speech")
+				}
+				_, exists = falapi.GetModel(modelName, "text2speech")
+				if !exists {
+					return fmt.Errorf("model not found: %s", modelName)
 				}
 
-				// Create HTTP request for initial call
-				req, err := http.NewRequestWithContext(ctx, "POST", "https://queue.fal.run/fal-ai/minimax-tts/text-to-speech", bytes.NewBuffer(requestBody))
+				// Generate speech
+				audioResp, err := client.GenerateSpeech(ctx, text, voiceID)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to generate speech: %v", err)
 				}
 
-				// Set headers
-				req.Header.Set("Content-Type", "application/json")
-				req.Header.Set("Authorization", "Key "+cfg.ExtraConfig["falapikey"])
-
-				// Send request
-				client := &http.Client{}
-				resp, err := client.Do(req)
+				// Fetch the audio data from the URL
+				resp, err := http.Get(audioResp.Audio.URL)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to fetch audio data: %v", err)
 				}
 				defer resp.Body.Close()
 
-				// Read response
-				body, err := io.ReadAll(resp.Body)
+				audioData, err := io.ReadAll(resp.Body)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to read audio data: %v", err)
 				}
 
-				// Debug output for initial response
+				// Convert PCM to Opus using the audio package
+				opusData, err := audio.ConvertPCMToOpus(audioData)
+				if err != nil {
+					return fmt.Errorf("failed to convert audio to Opus: %v", err)
+				}
+
 				if debug {
-					fmt.Printf("Initial Response: %s\n", string(body))
+					fmt.Printf("Opus data size before encoding: %d bytes\n", len(opusData))
 				}
 
-				// Parse initial response to get request ID
-				var initialResp struct {
-					RequestID string `json:"request_id"`
-				}
-				if err := json.Unmarshal(body, &initialResp); err != nil {
-					return err
-				}
+				// Encode as base64
+				encodedAudio := base64.StdEncoding.EncodeToString(opusData)
 
-				if initialResp.RequestID == "" {
-					return bot.SendPM(ctx, pm.Nick, "Error: No request ID received from the API")
+				if debug {
+					fmt.Printf("Base64 encoded size: %d bytes\n", len(encodedAudio))
 				}
 
-				// Poll until completion
-				ticker := time.NewTicker(500 * time.Millisecond)
-				defer ticker.Stop()
+				// Create the message with embedded audio in BisonRelay format
+				message := fmt.Sprintf("--embed[alt=%s,type=%s,filename=%s,data=%s]--",
+					url.QueryEscape("Text to Speech"),
+					"audio/ogg",
+					time.Now().Format("2006-01-02-15_04_05")+"-tts.opus",
+					encodedAudio)
 
-				for {
-					select {
-					case <-ctx.Done():
-						return ctx.Err()
-					case <-ticker.C:
-						// Check status using the request ID
-						statusURL := fmt.Sprintf("https://queue.fal.run/fal-ai/minimax-tts/requests/%s/status", initialResp.RequestID)
-						statusReq, err := http.NewRequestWithContext(ctx, "GET", statusURL, nil)
-						if err != nil {
-							return err
-						}
-						statusReq.Header.Set("Authorization", "Key "+cfg.ExtraConfig["falapikey"])
-
-						statusResp, err := client.Do(statusReq)
-						if err != nil {
-							return err
-						}
-
-						statusBody, err := io.ReadAll(statusResp.Body)
-						statusResp.Body.Close()
-						if err != nil {
-							return err
-						}
-
-						// Debug output for status response
-						if debug {
-							fmt.Printf("Status Response: %s\n", string(statusBody))
-						}
-
-						var statusResponse struct {
-							Status        string `json:"status"`
-							QueuePosition int    `json:"queue_position,omitempty"`
-						}
-						if err := json.Unmarshal(statusBody, &statusResponse); err != nil {
-							return err
-						}
-
-						switch statusResponse.Status {
-						case "IN_QUEUE":
-							// Send queue position update
-							bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Your request is in queue. Position: %d", statusResponse.QueuePosition))
-							continue
-						case "IN_PROGRESS":
-							// Send processing status
-							bot.SendPM(ctx, pm.Nick, "Your audio is being generated, please be patient")
-							continue
-						case "COMPLETED":
-							// Fetch final response using the request ID
-							resultURL := fmt.Sprintf("https://queue.fal.run/fal-ai/minimax-tts/requests/%s", initialResp.RequestID)
-							finalReq, err := http.NewRequestWithContext(ctx, "GET", resultURL, nil)
-							if err != nil {
-								return err
-							}
-							finalReq.Header.Set("Authorization", "Key "+cfg.ExtraConfig["falapikey"])
-
-							finalResp, err := client.Do(finalReq)
-							if err != nil {
-								return err
-							}
-							defer finalResp.Body.Close()
-
-							// Check the status code
-							if finalResp.StatusCode != http.StatusOK {
-								body, _ := io.ReadAll(finalResp.Body) // Read the body for logging
-								return bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Error fetching final response: %s. Body: %s", finalResp.Status, string(body)))
-							}
-
-							finalBody, err := io.ReadAll(finalResp.Body)
-							if err != nil {
-								return err
-							}
-
-							// Debug output
-							if debug {
-								fmt.Printf("Final Response Body: %s\n", string(finalBody))
-							}
-
-							// Unmarshal the final response
-							var finalResponse struct {
-								Audio struct {
-									URL         string `json:"url"`
-									ContentType string `json:"content_type"`
-									FileName    string `json:"file_name"`
-									FileSize    int    `json:"file_size"`
-								} `json:"audio"`
-								DurationMs int `json:"duration_ms"`
-							}
-							if err := json.Unmarshal(finalBody, &finalResponse); err != nil {
-								return err
-							}
-
-							// Fetch the audio data
-							audioResp, err := http.Get(finalResponse.Audio.URL)
-							if err != nil {
-								return err
-							}
-							defer audioResp.Body.Close()
-
-							audioData, err := io.ReadAll(audioResp.Body)
-							if err != nil {
-								return err
-							}
-
-							// Convert PCM to Opus using the audio package
-							opusData, err := audio.ConvertPCMToOpus(audioData)
-							if err != nil {
-								return fmt.Errorf("failed to convert audio to Opus: %v", err)
-							}
-
-							if debug {
-								fmt.Printf("Opus data size before encoding: %d bytes\n", len(opusData))
-							}
-
-							// Encode as base64
-							encodedAudio := base64.StdEncoding.EncodeToString(opusData)
-
-							if debug {
-								fmt.Printf("Base64 encoded size: %d bytes\n", len(encodedAudio))
-							}
-
-							// Create the message with embedded audio in BisonRelay format
-							message := fmt.Sprintf("--embed[alt=%s,type=%s,filename=%s,data=%s]--",
-								url.QueryEscape("Text to Speech"),
-								"audio/ogg",
-								time.Now().Format("2006-01-02-15_04_05")+"-tts.opus",
-								encodedAudio)
-
-							// Debug output
-							if debug {
-								fmt.Printf("Message for the User of the Audio file: %s\n", message)
-							}
-							return bot.SendPM(ctx, pm.Nick, message)
-						case "FAILED":
-							// Send the complete raw response body as PM
-							responseMessage := fmt.Sprintf("Failed to generate speech. Complete response: %s", string(statusBody))
-							return bot.SendPM(ctx, pm.Nick, responseMessage)
-						default:
-							// Still processing, continue polling
-							continue
-						}
-					}
+				// Debug output
+				if debug {
+					fmt.Printf("Message for the User of the Audio file: %s\n", message)
 				}
+				return bot.SendPM(ctx, pm.Nick, message)
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -475,7 +475,7 @@ func init() {
 				}
 
 				// Generate speech
-				audioResp, err := client.GenerateSpeech(ctx, text, voiceID)
+				audioResp, err := client.GenerateSpeech(ctx, text, voiceID, bot, pm.Nick)
 				if err != nil {
 					return fmt.Errorf("failed to generate speech: %v", err)
 				}


### PR DESCRIPTION
move fal-api functionality into a client and support text2image for all models. Also include a progress-bar info to the user for models that need longer render time

Make sure we have the same sample rate in the pcm audio file fal-api delivers and the ogg converter. Both sides support a 24k bit sample rate.