### PR TITLE
Asset server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Home directory
+~/
+
+# Go specific
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+go.work
+
+# Binary files
+bin/
+dist/
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS specific files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Log files
+*.log
+logs/
+
+# Config files (optional, uncomment if needed)
+# *.conf
+# config.json
+
+# Temporary files
+tmp/
+temp/ 

--- a/internal/assetserver/README.md
+++ b/internal/assetserver/README.md
@@ -1,0 +1,50 @@
+# Asset Server Client Package
+
+This package provides a client for interacting with the braibot-assetserver, which handles file uploads for the braibot application.
+
+## Features
+
+- Simple file upload interface
+- Automatic multipart form handling
+- Error handling and response parsing
+- Configurable server URL and API key
+
+## Usage
+
+```go
+import "github.com/karamble/braibot/internal/assetserver"
+
+// Create a new client
+client := assetserver.NewClient("https://assets.example.com", "your-api-key")
+
+// Upload a file
+fileData := []byte("file contents")
+resp, err := client.UploadFile("example.jpg", fileData)
+if err != nil {
+    // Handle error
+}
+
+// Use the download URL
+downloadURL := resp.URL
+```
+
+## Configuration
+
+The client requires two configuration parameters:
+- `serverURL`: The base URL of the assetserver (e.g., "https://assets.example.com")
+- `apiKey`: The API key for authentication
+
+## Response Format
+
+The upload response includes:
+- `Success`: Boolean indicating if the upload was successful
+- `Message`: Status message from the server
+- `URL`: Download URL for the uploaded file (only present on success)
+
+## Error Handling
+
+The client provides detailed error messages for:
+- Network errors
+- Authentication failures
+- Server errors
+- File upload failures 

--- a/internal/assetserver/client.go
+++ b/internal/assetserver/client.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2025 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package assetserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"path/filepath"
+)
+
+// Client represents a client for the braibot-assetserver
+type Client struct {
+	serverURL string
+	apiKey    string
+	client    *http.Client
+}
+
+// UploadResponse represents the response from the assetserver
+type UploadResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+	URL     string `json:"url,omitempty"`
+}
+
+// NewClient creates a new assetserver client
+func NewClient(serverURL, apiKey string) *Client {
+	return &Client{
+		serverURL: serverURL,
+		apiKey:    apiKey,
+		client:    &http.Client{},
+	}
+}
+
+// UploadFile uploads a file to the assetserver and returns the download URL
+func (c *Client) UploadFile(filename string, fileData []byte) (*UploadResponse, error) {
+	// Create a buffer to store the multipart form data
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	// Create a form file writer for the file
+	part, err := writer.CreateFormFile("file", filepath.Base(filename))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create form file: %v", err)
+	}
+
+	// Write the file data
+	if _, err := part.Write(fileData); err != nil {
+		return nil, fmt.Errorf("failed to write file data: %v", err)
+	}
+
+	// Close the multipart writer
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close multipart writer: %v", err)
+	}
+
+	// Create the request
+	req, err := http.NewRequest("POST", c.serverURL+"/upload", body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// Set headers
+	req.Header.Set("X-API-Key", c.apiKey)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	// Send the request
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned error status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	// Parse the response
+	var uploadResp UploadResponse
+	if err := json.Unmarshal(respBody, &uploadResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	// Check if upload was successful
+	if !uploadResp.Success {
+		return &uploadResp, fmt.Errorf("upload failed: %s", uploadResp.Message)
+	}
+
+	return &uploadResp, nil
+}

--- a/internal/falapi/types.go
+++ b/internal/falapi/types.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package falapi
 
 import "encoding/json"

--- a/main.go
+++ b/main.go
@@ -340,6 +340,200 @@ func isCommand(msg string) (string, []string, bool) {
 	return cmd, args, true
 }
 
+// testAssetServerCredentials tests if the asset server credentials are valid
+func testAssetServerCredentials(serverURL, apiKey string) error {
+	// Create HTTP client with timeout
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	// Create request
+	req, err := http.NewRequest("GET", serverURL+"/test", nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %v", err)
+	}
+
+	// Add API key header
+	req.Header.Set("X-API-Key", apiKey)
+
+	// Send request
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error connecting to asset server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("asset server returned error status %d", resp.StatusCode)
+	}
+
+	// Parse response
+	var result struct {
+		Success bool   `json:"success"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !result.Success {
+		return fmt.Errorf("asset server test failed: %s", result.Message)
+	}
+
+	return nil
+}
+
+// checkAndUpdateConfig checks if required configuration settings are present
+// and prompts the user to enter them if they're missing.
+func checkAndUpdateConfig(cfg *config.BotConfig) error {
+	// Ensure the directory exists first
+	if err := os.MkdirAll(*flagAppRoot, 0755); err != nil {
+		return fmt.Errorf("error creating app root directory: %v", err)
+	}
+
+	// Check for falapikey
+	if _, exists := cfg.ExtraConfig["falapikey"]; !exists {
+		fmt.Print("Enter your Fal.ai API key: ")
+		reader := bufio.NewReader(os.Stdin)
+		apiKey, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("error reading API key: %v", err)
+		}
+		apiKey = strings.TrimSpace(apiKey)
+		if apiKey == "" {
+			return fmt.Errorf("API key cannot be empty")
+		}
+
+		// Update config in memory
+		cfg.ExtraConfig["falapikey"] = apiKey
+
+		// Append to config file
+		configPath := filepath.Join(*flagAppRoot, "braibot.conf")
+		f, err := os.OpenFile(configPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return fmt.Errorf("error opening config file: %v", err)
+		}
+		defer f.Close()
+
+		if _, err := f.WriteString(fmt.Sprintf("falapikey=%s\n", apiKey)); err != nil {
+			return fmt.Errorf("error writing to config file: %v", err)
+		}
+	}
+
+	// Check for asset server settings
+	if _, exists := cfg.ExtraConfig["use_assetserver"]; !exists {
+		var useAssetServer string
+		reader := bufio.NewReader(os.Stdin)
+		for {
+			fmt.Print("Do you want to use the asset server? (y/N): ")
+			input, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("error reading asset server preference: %v", err)
+			}
+			useAssetServer = strings.TrimSpace(strings.ToLower(input))
+			if useAssetServer == "y" || useAssetServer == "n" || useAssetServer == "" {
+				break
+			}
+			fmt.Println("Please enter 'y' or 'n' (or press Enter for no)")
+		}
+
+		// Convert y/n to true/false, default to false if empty
+		useAssetServerValue := "false"
+		if useAssetServer == "y" {
+			useAssetServerValue = "true"
+		}
+
+		// Update config in memory
+		cfg.ExtraConfig["use_assetserver"] = useAssetServerValue
+
+		// Append to config file
+		configPath := filepath.Join(*flagAppRoot, "braibot.conf")
+		f, err := os.OpenFile(configPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return fmt.Errorf("error opening config file: %v", err)
+		}
+		defer f.Close()
+
+		if _, err := f.WriteString(fmt.Sprintf("use_assetserver=%s\n", useAssetServerValue)); err != nil {
+			return fmt.Errorf("error writing to config file: %v", err)
+		}
+
+		// If asset server is enabled, get additional settings
+		if useAssetServerValue == "true" {
+			// Get asset server URL
+			fmt.Print("Enter the asset server URL (e.g., https://assets.example.com): ")
+			assetServerURL, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("error reading asset server URL: %v", err)
+			}
+			assetServerURL = strings.TrimSpace(assetServerURL)
+			if assetServerURL == "" {
+				return fmt.Errorf("asset server URL cannot be empty")
+			}
+
+			// Validate URL format
+			if !strings.HasPrefix(assetServerURL, "https://") {
+				return fmt.Errorf("asset server URL must start with https://")
+			}
+
+			// Update config in memory
+			cfg.ExtraConfig["assetserver_url"] = assetServerURL
+
+			// Append to config file
+			if _, err := f.WriteString(fmt.Sprintf("assetserver_url=%s\n", assetServerURL)); err != nil {
+				return fmt.Errorf("error writing to config file: %v", err)
+			}
+
+			// Get API secret
+			fmt.Print("Enter the asset server API secret: ")
+			apiSecret, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("error reading API secret: %v", err)
+			}
+			apiSecret = strings.TrimSpace(apiSecret)
+			if apiSecret == "" {
+				return fmt.Errorf("API secret cannot be empty")
+			}
+
+			// Update config in memory
+			cfg.ExtraConfig["assetserver_secret"] = apiSecret
+
+			// Append to config file
+			if _, err := f.WriteString(fmt.Sprintf("assetserver_secret=%s\n", apiSecret)); err != nil {
+				return fmt.Errorf("error writing to config file: %v", err)
+			}
+
+			// Test the credentials
+			fmt.Println("Testing asset server credentials...")
+			if err := testAssetServerCredentials(assetServerURL, apiSecret); err != nil {
+				fmt.Printf("Asset server test failed: %v\n", err)
+				fmt.Println("Asset server will be disabled. You can try again later by editing the config file.")
+
+				// Set use_assetserver to false
+				useAssetServerValue = "false"
+				cfg.ExtraConfig["use_assetserver"] = "false"
+
+				// Update the config file with the new value
+				configPath := filepath.Join(*flagAppRoot, "braibot.conf")
+				f, err := os.OpenFile(configPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+				if err != nil {
+					return fmt.Errorf("error opening config file: %v", err)
+				}
+				defer f.Close()
+
+				if _, err := f.WriteString(fmt.Sprintf("use_assetserver=false\n")); err != nil {
+					return fmt.Errorf("error writing to config file: %v", err)
+				}
+			} else {
+				fmt.Println("Asset server credentials verified successfully!")
+			}
+		}
+	}
+
+	return nil
+}
+
 func realMain() error {
 	flag.Parse()
 
@@ -373,6 +567,19 @@ func realMain() error {
 	cfg, err := config.LoadBotConfig(appRoot, "braibot.conf")
 	if err != nil {
 		return fmt.Errorf("failed to load config: %v", err)
+	}
+
+	// Wait for braibot.conf to be created
+	configPath := filepath.Join(appRoot, "braibot.conf")
+	for i := 0; i < 5; i++ { // Try for 5 seconds
+		if _, err := os.Stat(configPath); err == nil {
+			// File exists, proceed with checkAndUpdateConfig
+			if err := checkAndUpdateConfig(cfg); err != nil {
+				return fmt.Errorf("failed to check and update config: %v", err)
+			}
+			break
+		}
+		time.Sleep(time.Second)
 	}
 
 	// Create a bidirectional channel for PMs and tips


### PR DESCRIPTION
closes #6 
We introduce an internal client for file uploads to braibot-assetserver.

Additionally we include a setup wizard on first launch for the user to enter their fal-api credentials and the needed settings for the communication with braibot-assetserver (server-url, api secret, enable assetserver true/false) and append these settings to the braibot.conf that the BisonBotKit automatically created.