### PR TITLE
refactor fal pkg for options on each individual model

### DIFF
--- a/internal/commands/image2image.go
+++ b/internal/commands/image2image.go
@@ -16,7 +16,8 @@ import (
 )
 
 // Image2ImageCommand returns the image2image command
-func Image2ImageCommand(dbManager *database.DBManager, debug bool) Command {
+// It now requires an ImageService instance.
+func Image2ImageCommand(dbManager *database.DBManager, imageService *image.ImageService, debug bool) Command {
 	// Get the current model to use its description
 	model, exists := faladapter.GetCurrentModel("image2image")
 	if !exists {

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -2,11 +2,25 @@ package commands
 
 import (
 	"github.com/karamble/braibot/internal/database"
+	"github.com/karamble/braibot/internal/image"
+	"github.com/karamble/braibot/internal/speech"
+	"github.com/karamble/braibot/internal/video"
+	"github.com/karamble/braibot/pkg/fal"
+	kit "github.com/vctt94/bisonbotkit"
+	"github.com/vctt94/bisonbotkit/config"
 )
 
 // InitializeCommands creates and registers all available commands
-func InitializeCommands(dbManager *database.DBManager, debug bool) *Registry {
+func InitializeCommands(dbManager *database.DBManager, cfg *config.BotConfig, bot *kit.Bot, debug bool) *Registry {
 	registry := NewRegistry()
+
+	// Create Fal client (assuming API key is in extra config)
+	falClient := fal.NewClient(cfg.ExtraConfig["falapikey"], fal.WithDebug(debug))
+
+	// Create Services
+	imageService := image.NewImageService(falClient, dbManager, bot, debug)
+	videoService := video.NewVideoService(falClient, dbManager, bot, debug)
+	speechService := speech.NewSpeechService(falClient, dbManager, bot, debug)
 
 	// Register help command
 	registry.Register(HelpCommand(registry, dbManager))
@@ -15,12 +29,12 @@ func InitializeCommands(dbManager *database.DBManager, debug bool) *Registry {
 	registry.Register(ListModelsCommand())
 	registry.Register(SetModelCommand(registry))
 
-	// Register AI commands
-	registry.Register(Text2ImageCommand(dbManager, debug))
-	registry.Register(Text2SpeechCommand(dbManager, debug))
-	registry.Register(Image2ImageCommand(dbManager, debug))
-	registry.Register(Image2VideoCommand(dbManager, debug))
-	registry.Register(Text2VideoCommand(dbManager, debug))
+	// Register AI commands (using services)
+	registry.Register(Text2ImageCommand(dbManager, imageService, debug))
+	registry.Register(Text2SpeechCommand(dbManager, speechService, debug))
+	registry.Register(Image2ImageCommand(dbManager, imageService, debug))
+	registry.Register(Image2VideoCommand(dbManager, videoService, debug))
+	registry.Register(Text2VideoCommand(dbManager, videoService, debug))
 
 	// Register balance and rate commands
 	registry.Register(BalanceCommand(dbManager, debug))

--- a/internal/commands/text2image.go
+++ b/internal/commands/text2image.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/companyzero/bisonrelay/clientrpc/types"
@@ -16,7 +17,8 @@ import (
 )
 
 // Text2ImageCommand returns the text2image command
-func Text2ImageCommand(dbManager *database.DBManager, debug bool) Command {
+// It now requires an ImageService instance.
+func Text2ImageCommand(dbManager *database.DBManager, imageService *image.ImageService, debug bool) Command {
 	// Get the current model to use its description
 	model, exists := faladapter.GetCurrentModel("text2image")
 	if !exists {
@@ -50,19 +52,23 @@ func Text2ImageCommand(dbManager *database.DBManager, debug bool) Command {
 				return bot.SendPM(ctx, pm.Nick, "Please provide a prompt. Usage: !text2image [prompt]")
 			}
 
-			prompt := strings.Join(args, " ")
+			// Parse arguments and prompt
+			prompt, parsedReq, err := parseTextImageArgs(args)
+			if err != nil {
+				return bot.SendPM(ctx, pm.Nick, err.Error())
+			}
 
-			// Create Fal.ai client
-			client := fal.NewClient(cfg.ExtraConfig["falapikey"], fal.WithDebug(debug))
-
-			// Get model configuration
+			// Model config is needed for PriceUSD
 			model, exists := faladapter.GetCurrentModel("text2image")
 			if !exists {
 				return fmt.Errorf("no default model found for text2image")
 			}
 
-			// Create image service
-			imageService := image.NewImageService(client, dbManager, bot, debug)
+			// Don't create client here, use the one in the service
+			// client := fal.NewClient(cfg.ExtraConfig["falapikey"], fal.WithDebug(debug))
+
+			// Image service is now passed in
+			// imageService := image.NewImageService(client, dbManager, bot, debug)
 
 			// Create progress callback
 			progress := NewCommandProgressCallback(bot, pm.Nick, "text2image")
@@ -71,13 +77,24 @@ func Text2ImageCommand(dbManager *database.DBManager, debug bool) Command {
 			var userID zkidentity.ShortID
 			userID.FromBytes(pm.Uid)
 			req := &image.ImageRequest{
-				Prompt:    prompt,
-				ModelType: "text2image",
-				ModelName: model.Name,
-				Progress:  progress,
-				UserNick:  pm.Nick,
-				UserID:    userID,
-				PriceUSD:  model.PriceUSD,
+				Prompt:              prompt,
+				ModelType:           "text2image",
+				ModelName:           model.Name,
+				Progress:            progress,
+				UserNick:            pm.Nick,
+				UserID:              userID,
+				PriceUSD:            model.PriceUSD,
+				NumImages:           parsedReq.NumImages,
+				ImageSize:           parsedReq.ImageSize,
+				Seed:                parsedReq.Seed,
+				NumInferenceSteps:   parsedReq.NumInferenceSteps,
+				EnableSafetyChecker: parsedReq.EnableSafetyChecker,
+				SafetyTolerance:     parsedReq.SafetyTolerance,
+				OutputFormat:        parsedReq.OutputFormat,
+				NegativePrompt:      parsedReq.NegativePrompt,
+				GuidanceScale:       parsedReq.GuidanceScale,
+				AspectRatio:         parsedReq.AspectRatio,
+				Raw:                 parsedReq.Raw,
 			}
 
 			// Generate image
@@ -93,4 +110,169 @@ func Text2ImageCommand(dbManager *database.DBManager, debug bool) Command {
 			return nil
 		},
 	}
+}
+
+// parseTextImageArgs parses the command arguments for text2image, separating the prompt
+// from known options.
+// It returns the prompt string, a partially populated ImageRequest struct containing
+// parsed options, and an error if parsing fails.
+func parseTextImageArgs(args []string) (string, *image.ImageRequest, error) {
+	var promptParts []string
+	parsedReq := &image.ImageRequest{
+		NumImages: 1, // Default
+		// Initialize pointers/zero values for optional fields
+		ImageSize:           "",
+		Seed:                nil,
+		NumInferenceSteps:   nil,
+		EnableSafetyChecker: nil,
+		SafetyTolerance:     "",
+		OutputFormat:        "",
+		NegativePrompt:      "",
+		GuidanceScale:       nil,
+		AspectRatio:         "",
+		Raw:                 nil,
+	}
+
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+		argLower := strings.ToLower(arg)
+
+		// Handle boolean flags like --flag=value
+		var flagValue string
+		if strings.Contains(argLower, "=") {
+			parts := strings.SplitN(argLower, "=", 2)
+			argLower = parts[0]
+			if len(parts) > 1 {
+				flagValue = parts[1]
+			}
+		}
+
+		switch argLower {
+		case "--num_images":
+			if i+1 < len(args) {
+				val, err := strconv.Atoi(args[i+1])
+				if err != nil || val <= 0 {
+					return "", nil, fmt.Errorf("invalid value for --num_images: '%s'. Must be a positive integer", args[i+1])
+				}
+				parsedReq.NumImages = val
+				i += 2
+			} else {
+				return "", nil, fmt.Errorf("missing value for --num_images argument")
+			}
+		case "--image_size":
+			if i+1 < len(args) {
+				parsedReq.ImageSize = args[i+1]
+				i += 2
+			} else {
+				return "", nil, fmt.Errorf("missing value for --image_size argument")
+			}
+		case "--seed":
+			if i+1 < len(args) {
+				val, err := strconv.Atoi(args[i+1])
+				if err != nil {
+					return "", nil, fmt.Errorf("invalid value for --seed: '%s'. Must be an integer", args[i+1])
+				}
+				parsedReq.Seed = &val
+				i += 2
+			} else {
+				return "", nil, fmt.Errorf("missing value for --seed argument")
+			}
+		case "--num_inference_steps":
+			if i+1 < len(args) {
+				val, err := strconv.Atoi(args[i+1])
+				if err != nil || val <= 0 {
+					return "", nil, fmt.Errorf("invalid value for --num_inference_steps: '%s'. Must be a positive integer", args[i+1])
+				}
+				parsedReq.NumInferenceSteps = &val
+				i += 2
+			} else {
+				return "", nil, fmt.Errorf("missing value for --num_inference_steps argument")
+			}
+		case "--enable_safety_checker":
+			var val bool
+			var err error
+			if flagValue != "" { // Handle --flag=value
+				val, err = strconv.ParseBool(flagValue)
+				if err != nil {
+					return "", nil, fmt.Errorf("invalid value for --enable_safety_checker: '%s'. Must be true or false", flagValue)
+				}
+				i++ // Consume only the flag=value arg
+			} else if i+1 < len(args) && (strings.ToLower(args[i+1]) == "true" || strings.ToLower(args[i+1]) == "false") {
+				val, _ = strconv.ParseBool(args[i+1])
+				i += 2 // Consume flag and value
+			} else {
+				val = true // Assume --flag means true
+				i++        // Consume only the flag
+			}
+			parsedReq.EnableSafetyChecker = &val
+		case "--safety_tolerance":
+			if i+1 < len(args) {
+				parsedReq.SafetyTolerance = args[i+1]
+				i += 2
+			} else {
+				return "", nil, fmt.Errorf("missing value for --safety_tolerance argument")
+			}
+		case "--output_format":
+			if i+1 < len(args) {
+				parsedReq.OutputFormat = strings.ToLower(args[i+1])
+				i += 2
+			} else {
+				return "", nil, fmt.Errorf("missing value for --output_format argument")
+			}
+		case "--negative_prompt", "--negative-prompt":
+			if i+1 < len(args) {
+				parsedReq.NegativePrompt = args[i+1] // Keep original case for prompt
+				i += 2
+			} else {
+				return "", nil, fmt.Errorf("missing value for --negative_prompt argument")
+			}
+		case "--guidance_scale", "--guidance-scale":
+			if i+1 < len(args) {
+				val, err := strconv.ParseFloat(args[i+1], 64)
+				if err != nil {
+					return "", nil, fmt.Errorf("invalid value for --guidance_scale: %s", args[i+1])
+				}
+				parsedReq.GuidanceScale = &val
+				i += 2
+			} else {
+				return "", nil, fmt.Errorf("missing value for --guidance_scale argument")
+			}
+		case "--aspect_ratio", "--aspect-ratio":
+			if i+1 < len(args) {
+				parsedReq.AspectRatio = args[i+1]
+				i += 2
+			} else {
+				return "", nil, fmt.Errorf("missing value for --aspect_ratio argument")
+			}
+		case "--raw":
+			var val bool
+			var err error
+			if flagValue != "" { // Handle --flag=value
+				val, err = strconv.ParseBool(flagValue)
+				if err != nil {
+					return "", nil, fmt.Errorf("invalid value for --raw: '%s'. Must be true or false", flagValue)
+				}
+				i++
+			} else if i+1 < len(args) && (strings.ToLower(args[i+1]) == "true" || strings.ToLower(args[i+1]) == "false") {
+				val, _ = strconv.ParseBool(args[i+1])
+				i += 2
+			} else {
+				val = true // Assume --raw means true
+				i++
+			}
+			parsedReq.Raw = &val
+		default:
+			// Assume it's part of the prompt
+			promptParts = append(promptParts, args[i]) // Use original arg with case preserved
+			i++
+		}
+	}
+
+	prompt := strings.Join(promptParts, " ")
+	if prompt == "" {
+		return "", nil, fmt.Errorf("please provide a prompt text")
+	}
+
+	return prompt, parsedReq, nil
 }

--- a/internal/commands/text2speech.go
+++ b/internal/commands/text2speech.go
@@ -2,186 +2,234 @@ package commands
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
-	"io"
-	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/companyzero/bisonrelay/clientrpc/types"
 	"github.com/companyzero/bisonrelay/zkidentity"
-	"github.com/decred/dcrd/dcrutil/v4"
-	"github.com/karamble/braibot/internal/audio"
 	"github.com/karamble/braibot/internal/database"
 	"github.com/karamble/braibot/internal/faladapter"
+	"github.com/karamble/braibot/internal/speech"
 	"github.com/karamble/braibot/pkg/fal"
 	kit "github.com/vctt94/bisonbotkit"
 	"github.com/vctt94/bisonbotkit/config"
 )
 
 // Text2SpeechCommand returns the text2speech command
-func Text2SpeechCommand(dbManager *database.DBManager, debug bool) Command {
+func Text2SpeechCommand(dbManager *database.DBManager, speechService *speech.SpeechService, debug bool) Command {
+	// Get the current model to use its description and help doc
+	model, exists := faladapter.GetCurrentModel("text2speech")
+	if !exists {
+		model = fal.Model{
+			Name:        "text2speech",
+			Description: "Converts text to speech using AI.",
+			HelpDoc:     "Usage: !text2speech [voice_id] [text]\nDefault voice: Wise_Woman. Please provide text to convert.",
+		}
+	}
+
+	description := model.Description // Use the model description
+	help := model.HelpDoc            // Use the model help doc
+
 	return Command{
 		Name:        "text2speech",
-		Description: "Converts text to speech. Usage: !text2speech [voice_id] [text] - voice_id is optional, defaults to Wise_Woman. Available voices: Wise_Woman, Friendly_Person, Inspirational_girl, Deep_Voice_Man, Calm_Woman, Casual_Guy, Lively_Girl, Patient_Man, Young_Knight, Determined_Man, Lovely_Girl, Decent_Boy, Imposing_Manner, Elegant_Man, Abbess, Sweet_Girl_2, Exuberant_Girl",
+		Description: description,
 		Handler: func(ctx context.Context, bot *kit.Bot, cfg *config.BotConfig, pm types.ReceivedPM, args []string) error {
 			if len(args) < 1 {
-				voiceList := "Available voices: Wise_Woman, Friendly_Person, Inspirational_girl, Deep_Voice_Man, Calm_Woman, Casual_Guy, Lively_Girl, Patient_Man, Young_Knight, Determined_Man, Lovely_Girl, Decent_Boy, Imposing_Manner, Elegant_Man, Abbess, Sweet_Girl_2, Exuberant_Girl"
-				return bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Please provide text to convert to speech. Usage: !text2speech [voice_id] [text]\n\n%s", voiceList))
+				return bot.SendPM(ctx, pm.Nick, help) // Send detailed help doc
 			}
 
-			// Get the text to convert - join all arguments after the voice ID
-			var text string
-			var voiceID string
-
-			if len(args) > 1 {
-				// If voice ID is provided, use it and join remaining args for text
-				voiceID = args[0]
-				text = strings.Join(args[1:], " ")
-			} else {
-				// If no voice ID provided, use default and use all args for text
-				voiceID = "Wise_Woman" // Default voice ID
-				text = strings.Join(args, " ")
+			// Parse arguments using the helper
+			text, voiceID, options, err := parseTextSpeechArgs(args)
+			if err != nil {
+				return bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Argument error: %v", err))
 			}
 
-			if text == "" {
-				return fmt.Errorf("please provide text to convert to speech")
-			}
-
-			// Get model configuration
+			// Get model configuration (required for PriceUSD)
 			model, exists := faladapter.GetCurrentModel("text2speech")
 			if !exists {
-				return fmt.Errorf("no default model found for text2speech")
+				return fmt.Errorf("no default model found for text2speech") // Should not happen if validation passed
 			}
-
-			// Convert model's USD price to DCR using current exchange rate
-			dcrAmount, err := USDToDCR(model.PriceUSD)
-			if err != nil {
-				return bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Error: %v", err))
-			}
-
-			// Convert DCR amount to atoms for comparison (1 DCR = 1e11 atoms)
-			dcrAtoms := int64(dcrAmount * 1e11)
-
-			// Get user balance in atoms
-			var userID zkidentity.ShortID
-			userID.FromBytes(pm.Uid)
-			userIDStr := userID.String()
-			balance, err := dbManager.GetBalance(userIDStr)
-			if err != nil {
-				return fmt.Errorf("failed to get balance: %v", err)
-			}
-
-			// Check if user has sufficient balance
-			if balance < dcrAtoms {
-				// Convert balance to DCR for display
-				balanceDCR := dcrutil.Amount(balance / 1e3).ToCoin()
-				return fmt.Errorf("insufficient balance. Required: %.8f DCR, Current: %.8f DCR", dcrAmount, balanceDCR)
-			}
-
-			// Send confirmation message
-			bot.SendPM(ctx, pm.Nick, "Processing your request.")
-
-			// Create Fal.ai client
-			client := fal.NewClient(cfg.ExtraConfig["falapikey"], fal.WithDebug(debug))
 
 			// Create progress callback
 			progress := NewCommandProgressCallback(bot, pm.Nick, "text2speech")
 
-			// Create speech request, populating the new Model field
-			req := fal.SpeechRequest{
-				Model:    model.Name, // Set the target model name
-				Text:     text,
-				VoiceID:  voiceID, // Use the selected or default voice ID
-				Progress: progress,
-				Options:  map[string]interface{}{}, // Options can be added here if needed later
+			// Create internal speech request
+			var userID zkidentity.ShortID
+			userID.FromBytes(pm.Uid)
+			req := &speech.SpeechRequest{
+				Text:      text,
+				VoiceID:   voiceID,
+				ModelName: model.Name, // Use current default model
+				Progress:  progress,
+				UserNick:  pm.Nick,
+				UserID:    userID,
+				PriceUSD:  model.PriceUSD,
 			}
 
-			// Generate speech using the adapter function with the request struct
-			resp, err := faladapter.GenerateSpeech(ctx, client, req, bot, pm.Nick)
+			// Populate options from the parsed map
+			if val, ok := options["speed"].(*float64); ok {
+				req.Speed = val
+			}
+			if val, ok := options["vol"].(*float64); ok {
+				req.Vol = val
+			}
+			if val, ok := options["pitch"].(*int); ok {
+				req.Pitch = val
+			}
+			if val, ok := options["emotion"].(string); ok {
+				req.Emotion = val
+			}
+			if val, ok := options["sample_rate"].(string); ok {
+				req.SampleRate = val
+			}
+			if val, ok := options["bitrate"].(string); ok {
+				req.Bitrate = val
+			}
+			if val, ok := options["format"].(string); ok {
+				req.Format = val
+			}
+			if val, ok := options["channel"].(string); ok {
+				req.Channel = val
+			}
+
+			// Generate speech using the service
+			result, err := speechService.GenerateSpeech(ctx, req)
 			if err != nil {
+				// Service handles billing checks/refunds, just return the error
 				return fmt.Errorf("failed to generate speech: %v", err)
 			}
 
-			// Log the response for debugging
-			if debug {
-				fmt.Printf("Speech generation response: %+v\n", resp)
+			if !result.Success {
+				// If service handled billing/refunds, error might already be user-friendly
+				errMsg := "speech generation failed"
+				if result.Error != nil {
+					errMsg += ": " + result.Error.Error()
+				}
+				return fmt.Errorf(errMsg)
 			}
 
-			// Check if the audio URL is empty
-			if resp.AudioURL == "" {
-				return fmt.Errorf("received empty audio URL from API")
-			}
-
-			// Fetch the audio data
-			audioResp, err := http.Get(resp.AudioURL)
-			if err != nil {
-				return fmt.Errorf("failed to fetch audio: %v", err)
-			}
-			defer audioResp.Body.Close()
-
-			audioData, err := io.ReadAll(audioResp.Body)
-			if err != nil {
-				return fmt.Errorf("failed to read audio data: %v", err)
-			}
-
-			// Convert the audio data to OGG/Opus format
-			opusData, err := audio.ConvertPCMToOpus(audioData)
-			if err != nil {
-				return fmt.Errorf("failed to convert audio to Opus: %v", err)
-			}
-
-			// Encode the opus data to base64
-			encodedAudio := base64.StdEncoding.EncodeToString(opusData)
-
-			// Create the message with embedded audio
-			message := fmt.Sprintf("--embed[alt=%s speech,type=audio/ogg,data=%s]--",
-				model.Name,
-				encodedAudio)
-			if err := bot.SendPM(ctx, pm.Nick, message); err != nil {
-				return fmt.Errorf("failed to send audio: %v", err)
-			}
-
-			// Deduct balance using CheckAndDeductBalance after successful delivery
-			hasBalance, err := dbManager.CheckAndDeductBalance(pm.Uid, model.PriceUSD, debug)
-			if err != nil {
-				return fmt.Errorf("failed to deduct balance: %v", err)
-			}
-			if !hasBalance {
-				return fmt.Errorf("failed to deduct balance. Please try again.")
-			}
-
-			// Get updated balance for billing message
-			newBalance, err := dbManager.GetUserBalance(pm.Uid)
-			if err != nil {
-				return fmt.Errorf("failed to get updated balance: %v", err)
-			}
-
-			// Send billing information with model's USD price and converted DCR amount
-			billingMsg := fmt.Sprintf("💰 Billing Information:\n• Charged: %.8f DCR ($%.2f USD)\n• Remaining Balance: %.8f DCR",
-				dcrAmount, model.PriceUSD, newBalance)
-			if err := bot.SendPM(ctx, pm.Nick, billingMsg); err != nil {
-				return fmt.Errorf("failed to send billing information: %v", err)
-			}
-
-			// Debug information
-			if debug {
-				fmt.Printf("DEBUG - Text2Speech command:\n")
-				fmt.Printf("  User ID: %s\n", userIDStr)
-				fmt.Printf("  Current balance (atoms): %d\n", balance)
-				fmt.Printf("  Cost in USD: $%.2f\n", model.PriceUSD)
-				fmt.Printf("  Cost in DCR: %.8f\n", dcrAmount)
-				fmt.Printf("  Cost in atoms: %d\n", dcrAtoms)
-				fmt.Printf("  Balance in DCR: %.8f\n", float64(balance)/1e11)
-			}
-
-			// Debug information after deduction
-			if debug {
-				fmt.Printf("DEBUG - After deduction:\n")
-				fmt.Printf("  New balance in DCR: %.8f\n", newBalance)
-			}
-
+			// Success message is handled by the service (audio embed + billing info)
 			return nil
 		},
 	}
+}
+
+// parseTextSpeechArgs parses the command arguments for text2speech.
+// It identifies an optional voice_id as the first argument if it doesn't start with '--'
+// and isn't likely part of a multi-word text when only one arg is given.
+// Returns the text, voice_id (or default), and parsed options map, and error.
+func parseTextSpeechArgs(args []string) (text, voiceID string, options map[string]interface{}, err error) {
+	defaultVoiceID := "Wise_Woman"
+	options = make(map[string]interface{})
+	var promptParts []string
+
+	if len(args) == 0 {
+		err = fmt.Errorf("please provide text to convert to speech")
+		return
+	}
+
+	// Identify voice ID
+	firstArgIsLikelyVoiceID := false
+	if len(args) > 1 && !strings.HasPrefix(args[0], "--") {
+		if len(strings.Split(args[0], "_")) > 1 && len(args[0]) < 30 { // Basic heuristic
+			firstArgIsLikelyVoiceID = true
+		}
+	}
+	if len(args) == 1 && !strings.HasPrefix(args[0], "--") {
+		if len(strings.Split(args[0], "_")) > 1 && len(args[0]) < 30 {
+			err = fmt.Errorf("voice ID '%s' provided, but no text found", args[0])
+			return
+		}
+	}
+
+	// Separate potential voice ID from other args
+	startIdx := 0
+	if firstArgIsLikelyVoiceID {
+		voiceID = args[0]
+		startIdx = 1
+	} else {
+		voiceID = defaultVoiceID
+	}
+
+	// Parse remaining args for flags and text
+	i := startIdx
+	for i < len(args) {
+		arg := args[i]
+		argLower := strings.ToLower(arg)
+
+		// Handle boolean flags like --flag=value (though none are bool here yet)
+		var flagValue string
+		if strings.Contains(argLower, "=") {
+			parts := strings.SplitN(argLower, "=", 2)
+			argLower = parts[0]
+			if len(parts) > 1 {
+				flagValue = parts[1]
+			}
+		}
+
+		if strings.HasPrefix(argLower, "--") {
+			flagName := strings.TrimPrefix(argLower, "--")
+			var value string
+			if flagValue != "" {
+				value = flagValue
+				i++ // Consume the flag=value arg
+			} else if i+1 < len(args) {
+				value = args[i+1]
+				i += 2 // Consume flag and value
+			} else {
+				err = fmt.Errorf("missing value for argument: %s", arg)
+				return
+			}
+
+			switch flagName {
+			case "speed":
+				fVal, parseErr := strconv.ParseFloat(value, 64)
+				if parseErr != nil {
+					err = fmt.Errorf("invalid value for --speed: %s", value)
+					return
+				}
+				options["speed"] = &fVal
+			case "vol":
+				fVal, parseErr := strconv.ParseFloat(value, 64)
+				if parseErr != nil {
+					err = fmt.Errorf("invalid value for --vol: %s", value)
+					return
+				}
+				options["vol"] = &fVal
+			case "pitch":
+				iVal, parseErr := strconv.Atoi(value)
+				if parseErr != nil {
+					err = fmt.Errorf("invalid value for --pitch: %s", value)
+					return
+				}
+				options["pitch"] = &iVal
+			case "emotion":
+				options["emotion"] = value
+			case "sample_rate":
+				options["sample_rate"] = value
+			case "bitrate":
+				options["bitrate"] = value
+			case "format":
+				options["format"] = strings.ToLower(value)
+			case "channel":
+				options["channel"] = value
+			default:
+				err = fmt.Errorf("unknown argument: %s", arg)
+				return
+			}
+		} else {
+			// Assume it's part of the prompt
+			promptParts = append(promptParts, arg)
+			i++
+		}
+	}
+
+	text = strings.Join(promptParts, " ")
+	if text == "" {
+		err = fmt.Errorf("please provide text to convert to speech")
+		return
+	}
+
+	return text, voiceID, options, nil
 }

--- a/internal/image/service.go
+++ b/internal/image/service.go
@@ -41,12 +41,18 @@ func (s *ImageService) GenerateImage(ctx context.Context, req *ImageRequest) (*I
 		return &ImageResult{Success: false, Error: err}, err
 	}
 
-	// 2. Check if user has sufficient balance
+	// 2. Calculate expected cost and check balance
+	numImagesToRequest := req.NumImages
+	if numImagesToRequest <= 0 {
+		numImagesToRequest = 1 // Default to 1 if not specified or invalid
+	}
+	totalExpectedCostUSD := req.PriceUSD * float64(numImagesToRequest)
+
 	pm := types.ReceivedPM{
 		Nick: req.UserNick,
 		Uid:  req.UserID[:],
 	}
-	billingResult, billingErr := utils.CheckAndProcessBilling(ctx, s.bot, s.dbManager, pm, req.PriceUSD, s.debug)
+	billingResult, billingErr := utils.CheckAndProcessBilling(ctx, s.bot, s.dbManager, pm, totalExpectedCostUSD, s.debug)
 	if billingErr != nil {
 		return &ImageResult{Success: false, Error: billingErr}, billingErr
 	}
@@ -57,83 +63,135 @@ func (s *ImageService) GenerateImage(ctx context.Context, req *ImageRequest) (*I
 	// 3. Send initial message
 	s.bot.SendPM(ctx, req.UserNick, "Processing your request.")
 
-	// 4. Generate image
-	var imageResp *fal.ImageResponse
-	var genErr error
-
-	// Create the unified image request for the fal client
-	imageReq := fal.ImageRequest{
-		Model:    req.ModelName,
-		Prompt:   req.Prompt, // Prompt might be empty for image2image
-		Progress: req.Progress,
-		Options:  make(map[string]interface{}), // Initialize options map
-	}
-
-	// Add image_url specifically for image2image types
-	if req.ModelType == "image2image" {
-		imageReq.Options["image_url"] = req.ImageURL
-	}
-	// Add other options if needed (e.g., num_images for text2image)
-	// Currently defaulting to 1 image in the example, could make this configurable
-	if req.ModelType == "text2image" {
-		imageReq.Options["num_images"] = 1
-	}
-
-	// Call the unified GenerateImage method on the fal client
-	imageResp, genErr = s.client.GenerateImage(ctx, imageReq)
-	if genErr != nil {
-		return &ImageResult{Success: false, Error: genErr}, genErr
-	}
-
-	// 5. Check if the image URL is empty
-	if len(imageResp.Images) == 0 || imageResp.Images[0].URL == "" {
-		genErr = fmt.Errorf("received empty image URL from API")
-		return &ImageResult{Success: false, Error: genErr}, genErr
-	}
-
-	// 6. Send the image
-	contentType := imageResp.Images[0].ContentType
-	if strings.Contains(contentType, "svg") || !strings.HasPrefix(contentType, "image/") {
-		// For SVG or non-standard image formats, use SendFile
-		if err := utils.SendFileToUser(ctx, s.bot, req.UserNick, imageResp.Images[0].URL, "image", contentType); err != nil {
-			return &ImageResult{Success: false, Error: err}, err
-		}
-	} else {
-		// For standard image formats, use PM embed
-		// Fetch the image data
-		imageResp, err := http.Get(imageResp.Images[0].URL)
-		if err != nil {
-			return &ImageResult{Success: false, Error: err}, err
-		}
-		defer imageResp.Body.Close()
-
-		imageData, err := io.ReadAll(imageResp.Body)
-		if err != nil {
-			return &ImageResult{Success: false, Error: err}, err
-		}
-
-		// Encode the image data to base64
-		encodedImage := base64.StdEncoding.EncodeToString(imageData)
-
-		// Create the message with embedded image
-		message := fmt.Sprintf("--embed[alt=%s image,type=%s,data=%s]--",
-			req.ModelName,
-			contentType,
-			encodedImage)
-		if err := s.bot.SendPM(ctx, req.UserNick, message); err != nil {
-			return &ImageResult{Success: false, Error: err}, err
-		}
-	}
-
-	// 7. Send billing info
-	if err := utils.SendBillingMessage(ctx, s.bot, pm, billingResult); err != nil {
+	// 4. Create the appropriate FAL request object using the helper function
+	falReq, err := createFalImageRequest(req, numImagesToRequest)
+	if err != nil {
+		// Handle error from request creation (e.g., unsupported model)
+		// Attempt to refund if billing was successful but we can't create the request
+		// if refundErr := utils.RefundBilling(ctx, s.bot, pm, billingResult); refundErr != nil {
+		// 	s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to process refund after request creation error: %v", refundErr))
+		// }
 		return &ImageResult{Success: false, Error: err}, err
 	}
 
-	return &ImageResult{
-		ImageURL: imageResp.Images[0].URL,
-		Success:  true,
-	}, nil
+	// 5. Generate image using the created request
+	imageResp, genErr := s.client.GenerateImage(ctx, falReq)
+	if genErr != nil {
+		// Attempt to refund if billing was successful but generation failed
+		// Note: Refund logic might need adjustment based on CheckAndProcessBilling behavior
+		// if err := utils.RefundBilling(ctx, s.bot, pm, billingResult); err != nil {
+		// 	 s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to process refund after generation error: %v", err))
+		// }
+		return &ImageResult{Success: false, Error: genErr}, genErr
+	}
+
+	// 6. Check if the image URL is empty - check if *any* images were returned
+	if len(imageResp.Images) == 0 {
+		genErr = fmt.Errorf("API did not return any images")
+		// Attempt to refund if billing was successful but generation failed
+		// Note: Refund logic might need adjustment based on CheckAndProcessBilling behavior
+		// if err := utils.RefundBilling(ctx, s.bot, pm, billingResult); err != nil {
+		// 	 s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to process refund after generation error: %v", err))
+		// }
+		return &ImageResult{Success: false, Error: genErr}, genErr
+	}
+
+	// 7. Send the image(s) - loop through results
+	numImagesGenerated := len(imageResp.Images)
+	successfullySentCount := 0
+	var lastSentImageURL string // Keep track of the last URL for the result
+	for i, img := range imageResp.Images {
+		if img.URL == "" {
+			s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Skipping image %d/%d: received empty URL from API.", i+1, numImagesGenerated))
+			continue
+		}
+		lastSentImageURL = img.URL // Update last URL
+		contentType := img.ContentType
+		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Sending image %d of %d...", i+1, numImagesGenerated))
+
+		if strings.Contains(contentType, "svg") || !strings.HasPrefix(contentType, "image/") {
+			// For SVG or non-standard image formats, use SendFile
+			if err := utils.SendFileToUser(ctx, s.bot, req.UserNick, img.URL, "image", contentType); err != nil {
+				s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to send image %d/%d: %v", i+1, numImagesGenerated, err))
+				// Optionally continue to try sending other images
+			} else {
+				successfullySentCount++
+			}
+		} else {
+			// For standard image formats, use PM embed
+			// Fetch the image data
+			imgDataResp, err := http.Get(img.URL)
+			if err != nil {
+				s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to fetch image %d/%d: %v", i+1, numImagesGenerated, err))
+				continue // Skip this image
+			}
+			defer imgDataResp.Body.Close()
+
+			imageData, err := io.ReadAll(imgDataResp.Body)
+			if err != nil {
+				s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to read image data %d/%d: %v", i+1, numImagesGenerated, err))
+				continue // Skip this image
+			}
+
+			// Encode the image data to base64
+			encodedImage := base64.StdEncoding.EncodeToString(imageData)
+
+			// Create the message with embedded image
+			message := fmt.Sprintf("--embed[alt=%s image %d/%d,type=%s,data=%s]--",
+				req.ModelName,
+				i+1,
+				numImagesGenerated,
+				contentType,
+				encodedImage)
+			if err := s.bot.SendPM(ctx, req.UserNick, message); err != nil {
+				s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to send embedded image %d/%d: %v", i+1, numImagesGenerated, err))
+				// Optionally continue
+			} else {
+				successfullySentCount++
+			}
+		}
+	}
+
+	// Send seed information if available
+	if imageResp.Seed != 0 {
+		seedMsg := fmt.Sprintf("🌱 Seed for the request: %d", imageResp.Seed)
+		if err := s.bot.SendPM(ctx, req.UserNick, seedMsg); err != nil {
+			fmt.Printf("WARN: Failed to send seed message to %s: %v\n", req.UserNick, err)
+		}
+	}
+
+	// 8. Send final confirmation and billing info
+	finalMessage := fmt.Sprintf("Finished processing request. Sent %d of %d generated image(s).\n\n", successfullySentCount, numImagesGenerated)
+
+	// Append billing info (using data from the initial check)
+	finalMessage += fmt.Sprintf("💰 Billing Information:\n• Charged: %.8f DCR ($%.2f USD)\n• Remaining Balance: %.8f DCR",
+		billingResult.ChargedDCR,
+		billingResult.ChargedUSD,
+		billingResult.NewBalance)
+
+	if err := s.bot.SendPM(ctx, req.UserNick, finalMessage); err != nil {
+		// Log error, but don't fail the whole operation just because the final message failed
+		fmt.Printf("ERROR: Failed to send final billing message to %s: %v\n", req.UserNick, err)
+	}
+
+	// Return success if at least one image was generated, using the last URL
+	if numImagesGenerated > 0 {
+		return &ImageResult{
+			ImageURL: lastSentImageURL, // Return the URL of the last image generated/sent
+			Success:  true,
+		}, nil
+	} else {
+		// This case should ideally be caught earlier, but as a fallback
+		return &ImageResult{Success: false, Error: fmt.Errorf("no images were generated successfully")}, nil
+	}
+}
+
+// Helper function to safely dereference optional int pointers
+func derefIntPtrOrDefault(ptr *int, defaultValue int) int {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
 }
 
 // validateRequest validates the image request
@@ -150,4 +208,138 @@ func (s *ImageService) validateRequest(req *ImageRequest) error {
 	}
 
 	return nil
+}
+
+// createFalImageRequest constructs the appropriate fal.Model request struct based on the internal ImageRequest.
+func createFalImageRequest(req *ImageRequest, numImagesToRequest int) (interface{}, error) {
+	var falReq interface{}
+
+	// Create the specific fal request based on the model name
+	switch req.ModelName {
+	case "fast-sdxl":
+		falReq = &fal.FastSDXLRequest{
+			BaseImageRequest: fal.BaseImageRequest{
+				Prompt:   req.Prompt,
+				Progress: req.Progress,
+			},
+			// fast-sdxl specific options parsed from req if added
+			NumImages: numImagesToRequest, // Use requested number
+		}
+	case "ghiblify":
+		if req.ImageURL == "" {
+			return nil, fmt.Errorf("image_url is required for ghiblify model")
+		}
+		falReq = &fal.GhiblifyRequest{
+			BaseImageRequest: fal.BaseImageRequest{
+				Prompt:   req.Prompt, // Optional prompt for ghiblify
+				ImageURL: req.ImageURL,
+				Progress: req.Progress,
+			},
+		}
+	case "cartoonify":
+		if req.ImageURL == "" {
+			return nil, fmt.Errorf("image_url is required for cartoonify model")
+		}
+		falReq = &fal.CartoonifyRequest{
+			BaseImageRequest: fal.BaseImageRequest{
+				Prompt:   req.Prompt, // Allow optional prompt?
+				ImageURL: req.ImageURL,
+				Progress: req.Progress,
+			},
+		}
+	case "star-vector":
+		if req.ImageURL == "" {
+			return nil, fmt.Errorf("image_url is required for star-vector model")
+		}
+		falReq = &fal.StarVectorRequest{
+			BaseImageRequest: fal.BaseImageRequest{
+				Prompt:   req.Prompt,
+				ImageURL: req.ImageURL,
+				Progress: req.Progress,
+			},
+		}
+	case "flux/schnell":
+		falReq = &fal.FluxSchnellRequest{
+			BaseImageRequest: fal.BaseImageRequest{
+				Prompt:   req.Prompt,
+				Progress: req.Progress,
+			},
+			NumImages:           numImagesToRequest,
+			ImageSize:           req.ImageSize,
+			Seed:                req.Seed,
+			NumInferenceSteps:   derefIntPtrOrDefault(req.NumInferenceSteps, 4),
+			EnableSafetyChecker: req.EnableSafetyChecker,
+		}
+	case "flux-pro/v1.1":
+		falReq = &fal.FluxProV1_1Request{
+			BaseImageRequest: fal.BaseImageRequest{
+				Prompt:   req.Prompt,
+				Progress: req.Progress,
+			},
+			NumImages:           numImagesToRequest,
+			ImageSize:           req.ImageSize,
+			Seed:                req.Seed,
+			EnableSafetyChecker: req.EnableSafetyChecker,
+			SafetyTolerance:     req.SafetyTolerance,
+			OutputFormat:        req.OutputFormat,
+		}
+	case "flux-pro/v1.1-ultra":
+		falReq = &fal.FluxProV1_1UltraRequest{
+			BaseImageRequest: fal.BaseImageRequest{
+				Prompt:   req.Prompt,
+				Progress: req.Progress,
+			},
+			NumImages:           numImagesToRequest,
+			Seed:                req.Seed,
+			EnableSafetyChecker: req.EnableSafetyChecker,
+			SafetyTolerance:     req.SafetyTolerance,
+			OutputFormat:        req.OutputFormat,
+			AspectRatio:         req.AspectRatio,
+			Raw:                 req.Raw,
+		}
+	case "hidream-i1-full":
+		falReq = &fal.HiDreamI1FullRequest{
+			BaseImageRequest:    fal.BaseImageRequest{Prompt: req.Prompt, Progress: req.Progress},
+			NegativePrompt:      req.NegativePrompt,
+			ImageSize:           req.ImageSize,
+			NumInferenceSteps:   req.NumInferenceSteps,
+			Seed:                req.Seed,
+			GuidanceScale:       req.GuidanceScale,
+			NumImages:           numImagesToRequest,
+			EnableSafetyChecker: req.EnableSafetyChecker,
+			OutputFormat:        req.OutputFormat,
+		}
+	case "hidream-i1-dev":
+		falReq = &fal.HiDreamI1DevRequest{
+			HiDreamI1FullRequest: fal.HiDreamI1FullRequest{
+				BaseImageRequest:    fal.BaseImageRequest{Prompt: req.Prompt, Progress: req.Progress},
+				NegativePrompt:      req.NegativePrompt,
+				ImageSize:           req.ImageSize,
+				NumInferenceSteps:   req.NumInferenceSteps,
+				Seed:                req.Seed,
+				GuidanceScale:       req.GuidanceScale,
+				NumImages:           numImagesToRequest,
+				EnableSafetyChecker: req.EnableSafetyChecker,
+				OutputFormat:        req.OutputFormat,
+			},
+		}
+	case "hidream-i1-fast":
+		falReq = &fal.HiDreamI1FastRequest{
+			HiDreamI1FullRequest: fal.HiDreamI1FullRequest{
+				BaseImageRequest:    fal.BaseImageRequest{Prompt: req.Prompt, Progress: req.Progress},
+				NegativePrompt:      req.NegativePrompt,
+				ImageSize:           req.ImageSize,
+				NumInferenceSteps:   req.NumInferenceSteps,
+				Seed:                req.Seed,
+				GuidanceScale:       req.GuidanceScale,
+				NumImages:           numImagesToRequest,
+				EnableSafetyChecker: req.EnableSafetyChecker,
+				OutputFormat:        req.OutputFormat,
+			},
+		}
+	// Add cases for other specific image models here
+	default:
+		return nil, fmt.Errorf("unsupported or unhandled model for specific FAL image request creation: %s", req.ModelName)
+	}
+	return falReq, nil
 }

--- a/internal/image/types.go
+++ b/internal/image/types.go
@@ -15,6 +15,19 @@ type ImageRequest struct {
 	UserNick  string
 	UserID    zkidentity.ShortID
 	PriceUSD  float64
+	NumImages int // Number of images requested (for models that support it)
+
+	// Model-specific options parsed from command args
+	ImageSize           string   // e.g., "landscape_4_3"
+	Seed                *int     // Optional seed
+	NumInferenceSteps   *int     // Optional steps (e.g., flux/schnell)
+	EnableSafetyChecker *bool    // Optional override
+	SafetyTolerance     string   // Optional tolerance (e.g., flux-pro)
+	OutputFormat        string   // Optional format (e.g., flux-pro)
+	NegativePrompt      string   // Optional negative prompt (e.g., hidream)
+	GuidanceScale       *float64 // Optional guidance scale (e.g., hidream)
+	AspectRatio         string   // Optional aspect ratio string (e.g., flux-ultra)
+	Raw                 *bool    // Optional raw flag (e.g., flux-ultra)
 }
 
 // ImageResult represents the result of an image generation

--- a/internal/speech/service.go
+++ b/internal/speech/service.go
@@ -1,0 +1,173 @@
+package speech
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/companyzero/bisonrelay/clientrpc/types"
+	"github.com/karamble/braibot/internal/database"
+	"github.com/karamble/braibot/internal/utils"
+	"github.com/karamble/braibot/pkg/fal"
+	kit "github.com/vctt94/bisonbotkit"
+)
+
+// SpeechService handles speech generation
+type SpeechService struct {
+	client    *fal.Client
+	dbManager *database.DBManager
+	bot       *kit.Bot
+	debug     bool
+}
+
+// NewSpeechService creates a new SpeechService
+func NewSpeechService(client *fal.Client, dbManager *database.DBManager, bot *kit.Bot, debug bool) *SpeechService {
+	return &SpeechService{
+		client:    client,
+		dbManager: dbManager,
+		bot:       bot,
+		debug:     debug,
+	}
+}
+
+// GenerateSpeech generates speech based on the internal request
+func (s *SpeechService) GenerateSpeech(ctx context.Context, req *SpeechRequest) (*SpeechResult, error) {
+	// 1. Check balance (No validation needed here as options are simple for now)
+	pm := types.ReceivedPM{
+		Nick: req.UserNick,
+		Uid:  req.UserID[:],
+	}
+	billingResult, billingErr := utils.CheckAndProcessBilling(ctx, s.bot, s.dbManager, pm, req.PriceUSD, s.debug)
+	if billingErr != nil {
+		return &SpeechResult{Success: false, Error: billingErr}, billingErr
+	}
+	if !billingResult.Success {
+		return &SpeechResult{Success: false, Error: fmt.Errorf(billingResult.ErrorMessage)}, nil
+	}
+
+	// 2. Send initial message
+	s.bot.SendPM(ctx, req.UserNick, "Processing your speech request.")
+
+	// 3. Create the appropriate FAL request object using the helper function
+	falReq, err := createFalSpeechRequest(req)
+	if err != nil {
+		// Optional: Refund logic
+		return &SpeechResult{Success: false, Error: err}, err
+	}
+
+	// 4. Generate speech using the created request
+	audioResp, err := s.client.GenerateSpeech(ctx, falReq)
+	if err != nil {
+		// Optional: Refund logic
+		return &SpeechResult{Success: false, Error: err}, err
+	}
+
+	// 5. Check if the audio URL is empty
+	if audioResp.AudioURL == "" {
+		err = fmt.Errorf("received empty audio URL from API")
+		// Optional: Refund logic
+		return &SpeechResult{Success: false, Error: err}, err
+	}
+
+	// 6. Download and send audio
+	if err := s.downloadAndSendAudio(ctx, req.UserNick, audioResp.AudioURL, req.ModelName); err != nil {
+		// Optional: Refund logic, although user was likely charged already
+		return &SpeechResult{Success: false, Error: err}, err
+	}
+
+	// 7. Send billing info
+	if err := utils.SendBillingMessage(ctx, s.bot, pm, billingResult); err != nil {
+		// Log error, but don't fail the whole operation
+		fmt.Printf("ERROR: Failed to send billing message to %s: %v\n", req.UserNick, err)
+	}
+
+	return &SpeechResult{
+		AudioURL: audioResp.AudioURL,
+		Success:  true,
+	}, nil
+}
+
+// downloadAndSendAudio fetches audio, saves to temp file, and sends via SendFile
+func (s *SpeechService) downloadAndSendAudio(ctx context.Context, userNick string, audioURL string, modelName string) error {
+	// Determine filename/extension (use info from response if available, else default)
+	// For now, defaulting to mp3 based on minimax default format
+	// A more robust approach would pass content_type from fal.AudioResponse
+	fileExtension := ".mp3"
+	fileNamePrefix := "speech-" + modelName + "-"
+
+	// Create a temporary file
+	tmpFile, err := os.CreateTemp("", fileNamePrefix+"*"+fileExtension)
+	if err != nil {
+		return fmt.Errorf("failed to create temp audio file: %v", err)
+	}
+	// Ensure the temp file is removed regardless of success/failure
+	defer func() {
+		err := os.Remove(tmpFile.Name())
+		if err != nil && !os.IsNotExist(err) {
+			fmt.Printf("WARN: Failed to remove temp audio file %s: %v\n", tmpFile.Name(), err)
+		}
+	}()
+
+	// Fetch the audio data
+	audioRespHTTP, err := http.Get(audioURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch audio: %v", err)
+	}
+	defer audioRespHTTP.Body.Close()
+
+	if audioRespHTTP.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to fetch audio: status code %d", audioRespHTTP.StatusCode)
+	}
+
+	// Copy the downloaded data to the temp file
+	_, err = io.Copy(tmpFile, audioRespHTTP.Body)
+	if err != nil {
+		// Attempt to close file before returning error
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to save audio to temp file: %v", err)
+	}
+
+	// Close the file before sending
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp audio file: %v", err)
+	}
+
+	// Send the file to the user
+	if err := s.bot.SendFile(ctx, userNick, tmpFile.Name()); err != nil {
+		return fmt.Errorf("failed to send audio file: %v", err)
+	}
+
+	return nil
+}
+
+// createFalSpeechRequest constructs the appropriate fal.Model request struct based on the internal SpeechRequest.
+func createFalSpeechRequest(req *SpeechRequest) (interface{}, error) {
+	var falReq interface{}
+
+	// Create the specific fal request based on the model name
+	switch req.ModelName {
+	case "minimax-tts/text-to-speech":
+		falReq = &fal.MinimaxTTSRequest{
+			BaseSpeechRequest: fal.BaseSpeechRequest{
+				Text:     req.Text,
+				Progress: req.Progress,
+			},
+			VoiceID: req.VoiceID, // Use parsed voice ID
+			// Copy parsed options
+			Speed:      req.Speed,
+			Vol:        req.Vol,
+			Pitch:      req.Pitch,
+			Emotion:    req.Emotion,
+			SampleRate: req.SampleRate,
+			Bitrate:    req.Bitrate,
+			Format:     req.Format,
+			Channel:    req.Channel,
+		}
+	// Add cases for other specific speech models here
+	default:
+		return nil, fmt.Errorf("unsupported or unhandled model for specific FAL speech request creation: %s", req.ModelName)
+	}
+	return falReq, nil
+}

--- a/internal/speech/types.go
+++ b/internal/speech/types.go
@@ -1,0 +1,33 @@
+package speech
+
+import (
+	"github.com/companyzero/bisonrelay/zkidentity"
+	"github.com/karamble/braibot/pkg/fal"
+)
+
+// SpeechRequest represents an internal request to generate speech
+type SpeechRequest struct {
+	Text      string
+	VoiceID   string // Optional, specific voice
+	ModelName string // Target model name
+	Progress  fal.ProgressCallback
+	UserNick  string
+	UserID    zkidentity.ShortID
+	PriceUSD  float64
+	// Parsed Options
+	Speed      *float64
+	Vol        *float64
+	Pitch      *int
+	Emotion    string
+	SampleRate string
+	Bitrate    string
+	Format     string
+	Channel    string
+}
+
+// SpeechResult represents the result of a speech generation
+type SpeechResult struct {
+	AudioURL string // URL of the generated audio
+	Success  bool
+	Error    error
+}

--- a/internal/video/types.go
+++ b/internal/video/types.go
@@ -8,24 +8,16 @@ import (
 // VideoRequest represents a request to generate a video
 type VideoRequest struct {
 	Prompt         string
-	ImageURL       string // Optional for text2video
-	Duration       string
-	AspectRatio    string
-	NegativePrompt string
-	CFGScale       float64
-	ModelType      string // "text2video" or "image2video"
+	ImageURL       string   // Optional for text2video
+	Duration       string   // Optional, defaults handled by FAL
+	AspectRatio    string   // Optional, defaults handled by FAL
+	NegativePrompt string   // Optional, defaults handled by FAL
+	CFGScale       *float64 // Optional, use pointer to track if set
+	ModelType      string   // "text2video" or "image2video"
 	Progress       fal.ProgressCallback
 	UserNick       string
 	UserID         zkidentity.ShortID
 	PriceUSD       float64
-}
-
-// VideoOptions represents the options for video generation
-type VideoOptions struct {
-	Duration       string
-	AspectRatio    string
-	NegativePrompt string
-	CFGScale       float64
 }
 
 // VideoResult represents the result of a video generation

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func realMain() error {
 	}
 
 	// Initialize command registry
-	commandRegistry := commands.InitializeCommands(dbManager, debug)
+	commandRegistry := commands.InitializeCommands(dbManager, cfg, bot, debug)
 
 	// Add a goroutine to handle PMs using our bidirectional channel
 	go func() {

--- a/pkg/fal/README.md
+++ b/pkg/fal/README.md
@@ -77,72 +77,107 @@ var progressCallback fal.ProgressCallback = &MyProgressTracker{}
 
 ### 3. Performing Generation Tasks
 
-**Text-to-Image:**
+**Text-to-Image (e.g., Flux Schnell):**
 
 ```go
-req := fal.ImageRequest{
-    Model:    "fast-sdxl", // Or another registered text2image model
-    Prompt:   "a futuristic cityscape at dusk",
-    Progress: progressCallback, // Optional
-    Options:  map[string]interface{}{"num_images": 1}, // Optional extra params
+// Use the specific request struct for type safety and defined options
+req := fal.FluxSchnellRequest{
+	BaseImageRequest: fal.BaseImageRequest{
+		Prompt:   "a hyperrealistic cat wearing sunglasses",
+		Progress: progressCallback, // Optional
+	},
+	// Set specific options for this model
+	NumImages: 2,
+	ImageSize: "square",
 }
-resp, err := client.GenerateImage(context.Background(), req)
+
+// Pass the specific request struct to GenerateImage
+resp, err := client.GenerateImage(context.Background(), &req)
 if err == nil {
-    fmt.Println("Image URL:", resp.Images[0].URL)
+	fmt.Println("Image URL:", resp.Images[0].URL)
+	// Access seed if needed: fmt.Println("Seed:", resp.Seed)
 }
 ```
 
 **Image-to-Image (e.g., Ghiblify):**
 
 ```go
-req := fal.ImageRequest{
-    Model:    "ghiblify", // Or another registered image2image model
-    Progress: progressCallback, // Optional
-    Options: map[string]interface{}{
-        "image_url": "https://example.com/input.jpg",
-        // Other model-specific options can go here
-    },
+// Use the specific request struct
+req := fal.GhiblifyRequest{
+	BaseImageRequest: fal.BaseImageRequest{
+		ImageURL: "https://example.com/input.jpg",
+		Progress: progressCallback, // Optional
+		// Prompt is optional for ghiblify but can be added here
+	},
+	// Ghiblify currently has no specific options beyond BaseImageRequest
 }
-resp, err := client.GenerateImage(context.Background(), req)
+
+// Pass the specific request struct to GenerateImage
+resp, err := client.GenerateImage(context.Background(), &req)
 // ... handle response ...
+```
+
+**Text-to-Speech (e.g., Minimax TTS):**
+
+```go
+// Use the specific request struct
+req := fal.MinimaxTTSRequest{
+	BaseSpeechRequest: fal.BaseSpeechRequest{
+		Text:     "Hello from the digital world!",
+		Progress: progressCallback, // Optional
+	},
+	// Set specific options for this model
+	VoiceID: "Calm_Woman",
+	Speed:   floatPtr(0.9), // Use helper for optional pointers if needed
+}
+
+// Pass the specific request struct to GenerateSpeech
+resp, err := client.GenerateSpeech(context.Background(), &req)
+if err == nil {
+    fmt.Println("Audio URL:", resp.AudioURL)
+}
+
+// Helper to get pointer for optional float (example)
+func floatPtr(f float64) *float64 { return &f }
 ```
 
 **Image-to-Video (e.g., Veo2):**
 
 ```go
 // Use the specific request struct for type safety and defaults
-veo2Req := fal.Veo2Request{
-    BaseVideoRequest: fal.BaseVideoRequest{
-        Prompt:   "make the cat dance",
-        ImageURL:  "https://example.com/cat.jpg",
-        Progress:  progressCallback, // Attach progress here
-    },
-    // Specific Veo2 options (will use defaults defined in model if empty)
-    Duration:    "8", 
-    AspectRatio: "16:9", 
+req := fal.Veo2Request{
+	BaseVideoRequest: fal.BaseVideoRequest{
+		Prompt:   "make the cat dance",
+		ImageURL: "https://example.com/cat.jpg",
+		Progress: progressCallback, // Attach progress here
+	},
+	// Specific Veo2 options (will use defaults defined in model if empty)
+	Duration:    "8",
+	AspectRatio: "16:9",
 }
 
 // Pass the specific request struct to GenerateVideo
-resp, err := client.GenerateVideo(context.Background(), &veo2Req) 
-if err == nil {
-    fmt.Println("Video URL:", resp.GetURL())
-}
+resp, err := client.GenerateVideo(context.Background(), &req)
+// ... handle response ...
 ```
 
-**Text-to-Speech (e.g., Minimax TTS):**
+**Text-to-Video (e.g., Kling Text):**
 
 ```go
-req := fal.SpeechRequest{
-    Model:    "minimax-tts/text-to-speech", // The registered model name
-    Text:     "The quick brown fox jumps over the lazy dog.",
-    VoiceID:  "Friendly_Person", // Parameter specific to this model
-    Progress: progressCallback, // Optional
-    Options:  map[string]interface{}{}, // Optional extra params
+// Use the specific request struct (KlingVideoRequest handles text/image variants)
+req := fal.KlingVideoRequest{
+	BaseVideoRequest: fal.BaseVideoRequest{
+		Prompt:   "a teddy bear playing drums on the moon",
+		Progress: progressCallback,
+	},
+	// Specific Kling options
+	Duration:    "10",
+	AspectRatio: "16:9",
 }
-resp, err := client.GenerateSpeech(context.Background(), req)
-if err == nil {
-    fmt.Println("Audio URL:", resp.AudioURL)
-}
+
+// Pass the specific request struct to GenerateVideo
+resp, err := client.GenerateVideo(context.Background(), &req)
+// ... handle response ...
 ```
 
 ### 4. Managing Models

--- a/pkg/fal/image.go
+++ b/pkg/fal/image.go
@@ -12,40 +12,303 @@ import (
 )
 
 // GenerateImage generates an image from a text prompt or image url
-func (c *Client) GenerateImage(ctx context.Context, req ImageRequest) (*ImageResponse, error) {
-	// Validate model type (text2image or image2image)
-	model, exists := GetModel(req.Model, "text2image")
-	if !exists {
-		model, exists = GetModel(req.Model, "image2image")
-		if !exists {
-			return nil, &Error{
-				Code:    "INVALID_MODEL",
-				Message: "invalid or unsupported model type for image generation: " + req.Model,
+// It accepts specific request types like *FastSDXLRequest or *GhiblifyRequest.
+func (c *Client) GenerateImage(ctx context.Context, req interface{}) (*ImageResponse, error) {
+	var modelName string
+	var modelType string
+	var endpoint string
+	var reqBody map[string]interface{}
+	var progress ProgressCallback
+	var baseReq *BaseImageRequest
+
+	// Extract progress callback and base request details
+	if progressable, ok := req.(Progressable); ok {
+		progress = progressable.GetProgress()
+	}
+
+	// Determine model name, endpoint and create request body based on request type
+	switch r := req.(type) {
+	case *FastSDXLRequest:
+		modelName = "fast-sdxl"
+		modelType = "text2image"
+		endpoint = "/fast-sdxl"
+		baseReq = &r.BaseImageRequest
+		reqBody = map[string]interface{}{
+			"prompt": r.Prompt,
+		}
+		if r.NumImages > 0 {
+			reqBody["num_images"] = r.NumImages
+		}
+		r.Model = modelName // Set model name internally
+	case *GhiblifyRequest:
+		modelName = "ghiblify"
+		modelType = "image2image"
+		endpoint = "/ghiblify"
+		baseReq = &r.BaseImageRequest
+		if r.ImageURL == "" {
+			return nil, fmt.Errorf("image_url is required for %s model", modelName)
+		}
+		reqBody = map[string]interface{}{
+			"image_url": r.ImageURL,
+		}
+		// Ghiblify might optionally use prompt, add if present
+		if r.Prompt != "" {
+			reqBody["prompt"] = r.Prompt
+		}
+		r.Model = modelName // Set model name internally
+	case *FluxSchnellRequest:
+		modelName = "flux/schnell"
+		modelType = "text2image"
+		endpoint = "/flux/schnell"
+		baseReq = &r.BaseImageRequest
+		// Validate specific options
+		opts := FluxSchnellOptions{
+			ImageSize:           r.ImageSize,
+			NumInferenceSteps:   r.NumInferenceSteps,
+			Seed:                r.Seed,
+			SyncMode:            r.SyncMode,
+			NumImages:           r.NumImages,
+			EnableSafetyChecker: r.EnableSafetyChecker,
+		}
+		if err := opts.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid options for %s: %v", modelName, err)
+		}
+		// Build request body from the specific request struct
+		reqBody = map[string]interface{}{
+			"prompt": r.Prompt, // From BaseImageRequest
+		}
+		if r.ImageSize != "" {
+			reqBody["image_size"] = r.ImageSize
+		}
+		if r.NumInferenceSteps > 0 { // Only include if non-default might be intended
+			reqBody["num_inference_steps"] = r.NumInferenceSteps
+		}
+		if r.Seed != nil {
+			reqBody["seed"] = *r.Seed
+		}
+		if r.SyncMode { // Only include if true
+			reqBody["sync_mode"] = r.SyncMode
+		}
+		if r.NumImages > 0 { // Only include if non-default might be intended
+			reqBody["num_images"] = r.NumImages
+		}
+		if r.EnableSafetyChecker != nil { // Include if explicitly set
+			reqBody["enable_safety_checker"] = *r.EnableSafetyChecker
+		}
+		r.Model = modelName // Set model name internally
+	case *FluxProV1_1Request:
+		modelName = "flux-pro/v1.1"
+		modelType = "text2image"
+		endpoint = "/flux-pro/v1.1"
+		baseReq = &r.BaseImageRequest
+		// Validate specific options
+		opts := FluxProV1_1Options{
+			ImageSize:           r.ImageSize,
+			Seed:                r.Seed,
+			SyncMode:            r.SyncMode,
+			NumImages:           r.NumImages,
+			EnableSafetyChecker: r.EnableSafetyChecker,
+			SafetyTolerance:     r.SafetyTolerance,
+			OutputFormat:        r.OutputFormat,
+		}
+		if err := opts.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid options for %s: %v", modelName, err)
+		}
+		// Build request body
+		reqBody = map[string]interface{}{
+			"prompt": r.Prompt,
+		}
+		if r.ImageSize != "" {
+			reqBody["image_size"] = r.ImageSize
+		}
+		if r.Seed != nil {
+			reqBody["seed"] = *r.Seed
+		}
+		if r.SyncMode {
+			reqBody["sync_mode"] = r.SyncMode
+		}
+		if r.NumImages > 0 {
+			reqBody["num_images"] = r.NumImages
+		}
+		if r.EnableSafetyChecker != nil {
+			reqBody["enable_safety_checker"] = *r.EnableSafetyChecker
+		}
+		if r.SafetyTolerance != "" {
+			reqBody["safety_tolerance"] = r.SafetyTolerance
+		}
+		if r.OutputFormat != "" {
+			reqBody["output_format"] = r.OutputFormat
+		}
+		r.Model = modelName // Set model name internally
+	// HiDream Models (assuming shared parameters)
+	case *HiDreamI1FullRequest, *HiDreamI1DevRequest, *HiDreamI1FastRequest:
+		// Determine modelName and get concrete request struct pointer
+		var concreteReq *HiDreamI1FullRequest
+		switch reqTyped := req.(type) { // Use new variable reqTyped
+		case *HiDreamI1FullRequest:
+			modelName = "hidream-i1-full"
+			concreteReq = reqTyped
+		case *HiDreamI1DevRequest:
+			modelName = "hidream-i1-dev"
+			concreteReq = &reqTyped.HiDreamI1FullRequest
+		case *HiDreamI1FastRequest:
+			modelName = "hidream-i1-fast"
+			concreteReq = &reqTyped.HiDreamI1FullRequest
+		default: // Should not happen due to outer case
+			return nil, fmt.Errorf("unexpected type within HiDream case: %T", req)
+		}
+		modelType = "text2image"
+		endpoint = "/" + modelName // Use model name as endpoint
+		baseReq = &concreteReq.BaseImageRequest
+		// Validate specific options
+		opts := HiDreamOptions{
+			NegativePrompt:      concreteReq.NegativePrompt,
+			ImageSize:           concreteReq.ImageSize,
+			NumInferenceSteps:   concreteReq.NumInferenceSteps,
+			Seed:                concreteReq.Seed,
+			GuidanceScale:       concreteReq.GuidanceScale,
+			SyncMode:            concreteReq.SyncMode,
+			NumImages:           concreteReq.NumImages,
+			EnableSafetyChecker: concreteReq.EnableSafetyChecker,
+			OutputFormat:        concreteReq.OutputFormat,
+		}
+		if err := opts.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid options for %s: %v", modelName, err)
+		}
+		// Build request body
+		reqBody = map[string]interface{}{"prompt": concreteReq.Prompt}
+		if concreteReq.NegativePrompt != "" {
+			reqBody["negative_prompt"] = concreteReq.NegativePrompt
+		}
+		if concreteReq.ImageSize != "" {
+			reqBody["image_size"] = concreteReq.ImageSize
+		}
+		if concreteReq.NumInferenceSteps != nil {
+			reqBody["num_inference_steps"] = *concreteReq.NumInferenceSteps
+		}
+		if concreteReq.Seed != nil {
+			reqBody["seed"] = *concreteReq.Seed
+		}
+		// Only include guidance_scale for the 'full' model
+		if modelName == "hidream-i1-full" && concreteReq.GuidanceScale != nil {
+			reqBody["guidance_scale"] = *concreteReq.GuidanceScale
+		}
+		if concreteReq.SyncMode {
+			reqBody["sync_mode"] = concreteReq.SyncMode
+		}
+		if concreteReq.NumImages > 0 {
+			reqBody["num_images"] = concreteReq.NumImages
+		}
+		if concreteReq.EnableSafetyChecker != nil {
+			reqBody["enable_safety_checker"] = *concreteReq.EnableSafetyChecker
+		}
+		if concreteReq.OutputFormat != "" {
+			reqBody["output_format"] = concreteReq.OutputFormat
+		}
+		concreteReq.Model = modelName
+	case *FluxProV1_1UltraRequest:
+		modelName = "flux-pro/v1.1-ultra"
+		modelType = "text2image"
+		endpoint = "/" + modelName
+		baseReq = &r.BaseImageRequest
+		// Validate specific options
+		opts := FluxProV1_1UltraOptions{
+			Seed:                r.Seed,
+			SyncMode:            r.SyncMode,
+			NumImages:           r.NumImages,
+			EnableSafetyChecker: r.EnableSafetyChecker,
+			SafetyTolerance:     r.SafetyTolerance,
+			OutputFormat:        r.OutputFormat,
+			AspectRatio:         r.AspectRatio,
+			Raw:                 r.Raw,
+		}
+		if err := opts.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid options for %s: %v", modelName, err)
+		}
+		// Build request body
+		reqBody = map[string]interface{}{"prompt": r.Prompt}
+		if r.Seed != nil {
+			reqBody["seed"] = *r.Seed
+		}
+		if r.SyncMode {
+			reqBody["sync_mode"] = r.SyncMode
+		}
+		if r.NumImages > 0 {
+			reqBody["num_images"] = r.NumImages
+		}
+		if r.EnableSafetyChecker != nil {
+			reqBody["enable_safety_checker"] = *r.EnableSafetyChecker
+		}
+		if r.SafetyTolerance != "" {
+			reqBody["safety_tolerance"] = r.SafetyTolerance
+		}
+		if r.OutputFormat != "" {
+			reqBody["output_format"] = r.OutputFormat
+		}
+		if r.AspectRatio != "" {
+			reqBody["aspect_ratio"] = r.AspectRatio
+		}
+		if r.Raw != nil {
+			reqBody["raw"] = *r.Raw
+		}
+		r.Model = modelName
+	// Image2Image Models
+	case *CartoonifyRequest:
+		modelName = "cartoonify"
+		modelType = "image2image"
+		endpoint = "/" + modelName
+		baseReq = &r.BaseImageRequest
+		if r.ImageURL == "" {
+			return nil, fmt.Errorf("image_url required for %s", modelName)
+		}
+		// Validate specific options (none currently)
+		opts := CartoonifyOptions{}
+		if err := opts.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid options for %s: %v", modelName, err)
+		}
+		// Build request body
+		reqBody = map[string]interface{}{"image_url": r.ImageURL}
+		if r.Prompt != "" {
+			reqBody["prompt"] = r.Prompt
+		} // Allow optional prompt
+		r.Model = modelName
+	case *StarVectorRequest:
+		modelName = "star-vector"
+		modelType = "image2image"
+		endpoint = "/fal-ai/star-vector" // Assuming full path based on potential complexity
+		baseReq = &r.BaseImageRequest
+		if r.ImageURL == "" {
+			return nil, fmt.Errorf("image_url required for %s", modelName)
+		}
+		// Validate specific options (none currently)
+		opts := StarVectorOptions{}
+		if err := opts.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid options for %s: %v", modelName, err)
+		}
+		// Build request body
+		reqBody = map[string]interface{}{"image_url": r.ImageURL}
+		r.Model = modelName
+	// case *OtherImageRequest:
+	// ...
+	default:
+		return nil, fmt.Errorf("unsupported image request type: %T", req)
+	}
+
+	// Validate the model existence (using inferred modelType)
+	if _, exists := GetModel(modelName, modelType); !exists {
+		return nil, &Error{
+			Code:    "INVALID_MODEL",
+			Message: fmt.Sprintf("model %s not found or not of expected type %s", modelName, modelType),
+		}
+	}
+
+	// Add any additional generic options from the base request
+	if baseReq != nil && baseReq.Options != nil {
+		for k, v := range baseReq.Options {
+			// Avoid overwriting fields already set by specific request types
+			if _, exists := reqBody[k]; !exists {
+				reqBody[k] = v
 			}
-		}
-	}
-
-	// Create request body
-	reqBody := map[string]interface{}{}
-	if model.Type == "text2image" {
-		reqBody["prompt"] = req.Prompt
-	} else { // image2image specific fields
-		if imgURL, ok := req.Options["image_url"]; ok {
-			reqBody["image_url"] = imgURL
-		} else {
-			return nil, fmt.Errorf("image_url is required for image2image models")
-		}
-		// Add prompt if provided for image2image (some models might use it)
-		if req.Prompt != "" {
-			reqBody["prompt"] = req.Prompt
-		}
-	}
-
-	// Add any additional common options
-	for k, v := range req.Options {
-		// Avoid overwriting primary fields like prompt or image_url
-		if k != "prompt" && k != "image_url" {
-			reqBody[k] = v
 		}
 	}
 
@@ -53,12 +316,14 @@ func (c *Client) GenerateImage(ctx context.Context, req ImageRequest) (*ImageRes
 	decodeFunc := func(data []byte) (interface{}, error) {
 		var response ImageResponse
 
-		// Try parsing as standard response (with images array)
+		// Try parsing as standard response (includes images array and top-level seed)
 		if err := json.Unmarshal(data, &response); err == nil && len(response.Images) > 0 {
+			// Seed is already captured in 'response' by the unmarshal
 			return &response, nil
 		}
 
 		// If that fails, try parsing as response with single 'image' or 'svg' field
+		// We also need to capture the top-level seed in this case.
 		var singleImageResp struct {
 			Image struct {
 				URL         string `json:"url"`
@@ -70,6 +335,7 @@ func (c *Client) GenerateImage(ctx context.Context, req ImageRequest) (*ImageRes
 				URL         string `json:"url"`
 				ContentType string `json:"content_type"`
 			} `json:"svg"`
+			Seed int `json:"seed"` // Capture top-level seed here too
 		}
 
 		if err := json.Unmarshal(data, &singleImageResp); err != nil {
@@ -107,11 +373,12 @@ func (c *Client) GenerateImage(ctx context.Context, req ImageRequest) (*ImageRes
 				Height:      imgHeight,
 			},
 		}
+		response.Seed = singleImageResp.Seed // Assign the captured seed
 		return &response, nil
 	}
 
 	// Execute the workflow
-	result, err := c.executeAsyncWorkflow(ctx, "/"+req.Model, reqBody, req.Progress, decodeFunc)
+	result, err := c.executeAsyncWorkflow(ctx, endpoint, reqBody, progress, decodeFunc)
 	if err != nil {
 		return nil, err // Error already wrapped by executeAsyncWorkflow
 	}

--- a/pkg/fal/image_image_models.go
+++ b/pkg/fal/image_image_models.go
@@ -29,6 +29,7 @@ func (m *cartoonifyModel) Define() Model {
 		PriceUSD:    0.02,
 		Type:        "image2image",
 		HelpDoc:     "Usage: !image2image [image_url]\nExample: !image2image https://example.com/image.jpg\n\nParameters:\n• image_url: URL of the image to transform",
+		Options:     &CartoonifyOptions{},
 	}
 }
 
@@ -43,9 +44,7 @@ func (m *starVectorModel) Define() Model {
 		PriceUSD:    1.0,
 		Type:        "image2image",
 		HelpDoc:     "Usage: !image2image [image_url]\nExample: !image2image https://example.com/image.jpg\n\nTo use this model, first set it as the default model:\n!setmodel image2image star-vector\n\nParameters:\n• image_url: URL of the source image\n\nPricing:\n• Base price: $1.0 per image",
-		// Note: This model doesn't seem to have specific options defined in the original code,
-		// even though its client usage might imply options. Keeping Options nil for now.
-		Options: nil,
+		Options:     &StarVectorOptions{},
 	}
 }
 

--- a/pkg/fal/speech.go
+++ b/pkg/fal/speech.go
@@ -11,35 +11,100 @@ import (
 )
 
 // GenerateSpeech generates speech from text using the specified model
-func (c *Client) GenerateSpeech(ctx context.Context, req SpeechRequest) (*AudioResponse, error) {
+// It accepts specific request types like *MinimaxTTSRequest.
+func (c *Client) GenerateSpeech(ctx context.Context, req interface{}) (*AudioResponse, error) {
+	var modelName string
+	var endpoint string
+	var reqBody map[string]interface{}
+	var progress ProgressCallback
+
+	// Extract progress callback if available
+	if progressable, ok := req.(Progressable); ok {
+		progress = progressable.GetProgress()
+	}
+
+	// Determine model name, endpoint and create request body based on request type
+	switch r := req.(type) {
+	case *MinimaxTTSRequest:
+		modelName = "minimax-tts/text-to-speech"
+		endpoint = "/" + modelName // Assuming endpoint matches model name
+
+		// Validate options based on request values
+		currentOpts := MinimaxTTSOptions{
+			Speed:      r.Speed,
+			Vol:        r.Vol,
+			Pitch:      r.Pitch,
+			Emotion:    r.Emotion,
+			SampleRate: r.SampleRate,
+			Bitrate:    r.Bitrate,
+			Format:     r.Format,
+			Channel:    r.Channel,
+		}
+		if err := currentOpts.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid options for %s: %v", modelName, err)
+		}
+
+		// Build nested request body structure
+		voiceSetting := make(map[string]interface{})
+		voiceSetting["voice_id"] = r.VoiceID // Always include voice ID
+		if r.Speed != nil {
+			voiceSetting["speed"] = *r.Speed
+		}
+		if r.Vol != nil {
+			voiceSetting["vol"] = *r.Vol
+		}
+		if r.Pitch != nil {
+			voiceSetting["pitch"] = *r.Pitch
+		}
+		if r.Emotion != "" {
+			voiceSetting["emotion"] = r.Emotion
+		}
+
+		audioSetting := make(map[string]interface{})
+		if r.SampleRate != "" {
+			audioSetting["sample_rate"] = r.SampleRate
+		}
+		if r.Bitrate != "" {
+			audioSetting["bitrate"] = r.Bitrate
+		}
+		if r.Format != "" {
+			audioSetting["format"] = r.Format
+		}
+		if r.Channel != "" {
+			audioSetting["channel"] = r.Channel
+		}
+
+		reqBody = map[string]interface{}{"text": r.Text}
+		if len(voiceSetting) > 1 { // Only add if more than just voice_id
+			reqBody["voice_setting"] = voiceSetting
+		}
+		if len(audioSetting) > 0 {
+			reqBody["audio_setting"] = audioSetting
+		}
+
+		r.Model = modelName // Set model name internally
+	// Add cases for other specific speech requests here
+	// case *OtherSpeechRequest:
+	// ...
+	default:
+		return nil, fmt.Errorf("unsupported speech request type: %T", req)
+	}
+
 	// Validate the requested model
-	if _, exists := GetModel(req.Model, "text2speech"); !exists {
+	if _, exists := GetModel(modelName, "text2speech"); !exists {
 		return nil, &Error{
 			Code:    "INVALID_MODEL",
-			Message: "invalid or unsupported model for text2speech: " + req.Model,
+			Message: fmt.Sprintf("invalid or unsupported model %s for text2speech", modelName),
 		}
 	}
 
-	// Use the model name to form the endpoint path
-	// Assumes the endpoint path directly corresponds to the model name for now.
-	// More complex routing might be needed if this assumption changes.
-	endpoint := "/" + req.Model
-
-	// Base request body
-	reqBody := map[string]interface{}{
-		"text": req.Text,
-	}
-
-	// Add model-specific parameters. Currently handling voice_id for minimax.
-	if req.Model == "minimax-tts/text-to-speech" && req.VoiceID != "" {
-		reqBody["voice_id"] = req.VoiceID
-	}
-
-	// Add any additional options from the request
-	for k, v := range req.Options {
-		// Avoid overwriting fields already set (text, voice_id for minimax)
-		if _, exists := reqBody[k]; !exists {
-			reqBody[k] = v
+	// Add any additional generic options from the request
+	if optionsGetter, ok := req.(interface{ GetOptions() map[string]interface{} }); ok {
+		for k, v := range optionsGetter.GetOptions() {
+			// Avoid overwriting fields already set by specific request types
+			if _, exists := reqBody[k]; !exists {
+				reqBody[k] = v
+			}
 		}
 	}
 
@@ -81,7 +146,7 @@ func (c *Client) GenerateSpeech(ctx context.Context, req SpeechRequest) (*AudioR
 	}
 
 	// Execute the workflow
-	result, err := c.executeAsyncWorkflow(ctx, endpoint, reqBody, req.Progress, decodeFunc)
+	result, err := c.executeAsyncWorkflow(ctx, endpoint, reqBody, progress, decodeFunc)
 	if err != nil {
 		return nil, err // Error already wrapped
 	}

--- a/pkg/fal/text_image_models.go
+++ b/pkg/fal/text_image_models.go
@@ -23,12 +23,27 @@ func (m *fastSDXLModel) Define() Model {
 type hidreamI1FullModel struct{}
 
 func (m *hidreamI1FullModel) Define() Model {
+	defaultOpts := &HiDreamOptions{}
+	defaults := defaultOpts.GetDefaultValues()
+	defaultSafetyChecker := defaults["enable_safety_checker"].(*bool)
+	defaultNumSteps := 50       // Correct default for full
+	defaultGuidanceScale := 5.0 // Correct default for full
+
 	return Model{
 		Name:        "hidream-i1-full",
-		Description: "High-quality model for detailed images",
+		Description: "High-quality model for detailed images (HiDream I1 Full 17B)",
 		PriceUSD:    0.10,
 		Type:        "text2image",
-		HelpDoc:     "Usage: !text2image \nExample: !text2image a beautiful sunset over mountains\n\nParameters:\n• prompt: Text description of the image you want to generate",
+		HelpDoc:     "Usage: !text2image [prompt] [--option value]...\nExample: !text2image a futuristic city --negative_prompt blur --guidance_scale 7\n\nParameters:\n• prompt: Text description (required)\n• --negative_prompt: Things to avoid (optional, default: \"\")\n• --image_size: Output dimensions (default: square_hd). Options: square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9\n• --num_inference_steps: Number of steps (default: 50)\n• --seed: Specific seed (optional)\n• --guidance_scale: Prompt adherence (default: 5.0)\n• --num_images: Number of images (default: 1)\n• --enable_safety_checker: Enable safety filter (default: true)\n• --output_format: jpeg, png (default: jpeg)",
+		Options: &HiDreamOptions{
+			NegativePrompt:      defaults["negative_prompt"].(string),
+			ImageSize:           defaults["image_size"].(string),
+			NumInferenceSteps:   &defaultNumSteps,      // Use correct default pointer
+			GuidanceScale:       &defaultGuidanceScale, // Use correct default pointer
+			NumImages:           defaults["num_images"].(int),
+			EnableSafetyChecker: defaultSafetyChecker,
+			OutputFormat:        defaults["output_format"].(string),
+		},
 	}
 }
 
@@ -37,12 +52,26 @@ func (m *hidreamI1FullModel) Define() Model {
 type hidreamI1DevModel struct{}
 
 func (m *hidreamI1DevModel) Define() Model {
+	// Get base defaults, then override for dev
+	baseDefaults := (&HiDreamOptions{}).GetDefaultValues()
+	devDefaultSteps := 28 // Default for dev
+	devSafetyChecker := baseDefaults["enable_safety_checker"].(*bool)
+
 	return Model{
 		Name:        "hidream-i1-dev",
 		Description: "Development version of the HiDream model",
 		PriceUSD:    0.06,
 		Type:        "text2image",
-		HelpDoc:     "Usage: !text2image \nExample: !text2image a beautiful sunset over mountains\n\nParameters:\n• prompt: Text description of the image you want to generate",
+		HelpDoc:     "Usage: !text2image [prompt] [--option value]...\nExample: !text2image a futuristic city --negative_prompt blur\n\nParameters:\n• prompt: Text description (required)\n• --negative_prompt: Things to avoid (optional, default: \"\")\n• --image_size: Output dimensions (default: square_hd). Options: square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9\n• --num_inference_steps: Number of steps (default: 28)\n• --seed: Specific seed (optional)\n• --num_images: Number of images (default: 1)\n• --enable_safety_checker: Enable safety filter (default: true)\n• --output_format: jpeg, png (default: jpeg)", // Removed guidance_scale
+		Options: &HiDreamOptions{
+			NegativePrompt:      baseDefaults["negative_prompt"].(string),
+			ImageSize:           baseDefaults["image_size"].(string),
+			NumInferenceSteps:   &devDefaultSteps, // Use dev default
+			GuidanceScale:       nil,              // Not applicable for dev
+			NumImages:           baseDefaults["num_images"].(int),
+			EnableSafetyChecker: devSafetyChecker,
+			OutputFormat:        baseDefaults["output_format"].(string),
+		},
 	}
 }
 
@@ -51,12 +80,26 @@ func (m *hidreamI1DevModel) Define() Model {
 type hidreamI1FastModel struct{}
 
 func (m *hidreamI1FastModel) Define() Model {
+	// Get base defaults, then override for fast
+	baseDefaults := (&HiDreamOptions{}).GetDefaultValues()
+	fastDefaultSteps := 16 // Default for fast
+	fastSafetyChecker := baseDefaults["enable_safety_checker"].(*bool)
+
 	return Model{
 		Name:        "hidream-i1-fast",
 		Description: "Faster version of the HiDream model",
 		PriceUSD:    0.03,
 		Type:        "text2image",
-		HelpDoc:     "Usage: !text2image \nExample: !text2image a beautiful sunset over mountains\n\nParameters:\n• prompt: Text description of the image you want to generate",
+		HelpDoc:     "Usage: !text2image [prompt] [--option value]...\nExample: !text2image a futuristic city --negative_prompt blur\n\nParameters:\n• prompt: Text description (required)\n• --negative_prompt: Things to avoid (optional, default: \"\")\n• --image_size: Output dimensions (default: square_hd). Options: square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9\n• --num_inference_steps: Number of steps (default: 16)\n• --seed: Specific seed (optional)\n• --num_images: Number of images (default: 1)\n• --enable_safety_checker: Enable safety filter (default: true)\n• --output_format: jpeg, png (default: jpeg)", // Removed guidance_scale
+		Options: &HiDreamOptions{
+			NegativePrompt:      baseDefaults["negative_prompt"].(string),
+			ImageSize:           baseDefaults["image_size"].(string),
+			NumInferenceSteps:   &fastDefaultSteps, // Use fast default
+			GuidanceScale:       nil,               // Not applicable for fast
+			NumImages:           baseDefaults["num_images"].(int),
+			EnableSafetyChecker: fastSafetyChecker,
+			OutputFormat:        baseDefaults["output_format"].(string),
+		},
 	}
 }
 
@@ -65,12 +108,25 @@ func (m *hidreamI1FastModel) Define() Model {
 type fluxProV1_1Model struct{}
 
 func (m *fluxProV1_1Model) Define() Model {
+	// Define default options
+	defaultOpts := &FluxProV1_1Options{}
+	defaults := defaultOpts.GetDefaultValues()
+	defaultSafetyChecker := defaults["enable_safety_checker"].(*bool)
+
 	return Model{
 		Name:        "flux-pro/v1.1",
-		Description: "Professional model for high-end image generation",
+		Description: "Professional model for high-end image generation (FLUX1.1 pro)",
 		PriceUSD:    0.08,
 		Type:        "text2image",
-		HelpDoc:     "Usage: !text2image \nExample: !text2image a beautiful sunset over mountains\n\nParameters:\n• prompt: Text description of the image you want to generate",
+		HelpDoc:     "Usage: !text2image [prompt] [--option value]...\nExample: !text2image a hyperrealistic cat --num_images 2 --image_size square\n\nParameters:\n• prompt: Text description of the image (required)\n• --image_size: Output dimensions (default: landscape_4_3). Options: square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9\n• --seed: Specific seed for reproducibility (optional)\n• --num_images: Number of images to generate (default: 1)\n• --enable_safety_checker: Enable safety filter (default: true). Use --enable_safety_checker=false to disable.\n• --safety_tolerance: Safety strictness (1-6, default: 2)\n• --output_format: Image format (jpeg, png. default: jpeg)",
+		Options: &FluxProV1_1Options{
+			ImageSize:           defaults["image_size"].(string),
+			NumImages:           defaults["num_images"].(int),
+			EnableSafetyChecker: defaultSafetyChecker,
+			SafetyTolerance:     defaults["safety_tolerance"].(string),
+			OutputFormat:        defaults["output_format"].(string),
+			// Seed and SyncMode default to nil/false
+		},
 	}
 }
 
@@ -79,12 +135,25 @@ func (m *fluxProV1_1Model) Define() Model {
 type fluxProV1_1UltraModel struct{}
 
 func (m *fluxProV1_1UltraModel) Define() Model {
+	defaultOpts := &FluxProV1_1UltraOptions{}
+	defaults := defaultOpts.GetDefaultValues()
+	defaultSafetyChecker := defaults["enable_safety_checker"].(*bool)
+	defaultRaw := defaults["raw"].(*bool)
+
 	return Model{
 		Name:        "flux-pro/v1.1-ultra",
-		Description: "Ultra version of the professional model",
+		Description: "Ultra version of the professional model (FLUX pro ultra)",
 		PriceUSD:    0.12,
 		Type:        "text2image",
-		HelpDoc:     "Usage: !text2image \nExample: !text2image a beautiful sunset over mountains\n\nParameters:\n• prompt: Text description of the image you want to generate",
+		HelpDoc:     "Usage: !text2image [prompt] [--option value]...\nExample: !text2image cinematic photo --aspect_ratio 9:16 --raw=true\n\nParameters:\n• prompt: Text description (required)\n• --seed: Specific seed (optional)\n• --num_images: Number of images (default: 1)\n• --enable_safety_checker: Enable safety filter (default: true)\n• --safety_tolerance: Safety strictness (1-6, default: 2)\n• --output_format: jpeg, png (default: jpeg)\n• --aspect_ratio: Output aspect ratio (default: 16:9). Options: 21:9, 16:9, 4:3, 3:2, 1:1, 2:3, 3:4, 9:16, 9:21\n• --raw: Generate less processed image (default: false)",
+		Options: &FluxProV1_1UltraOptions{
+			NumImages:           defaults["num_images"].(int),
+			EnableSafetyChecker: defaultSafetyChecker,
+			SafetyTolerance:     defaults["safety_tolerance"].(string),
+			OutputFormat:        defaults["output_format"].(string),
+			AspectRatio:         defaults["aspect_ratio"].(string),
+			Raw:                 defaultRaw,
+		},
 	}
 }
 
@@ -93,12 +162,24 @@ func (m *fluxProV1_1UltraModel) Define() Model {
 type fluxSchnellModel struct{}
 
 func (m *fluxSchnellModel) Define() Model {
+	// Define default options
+	defaultOpts := &FluxSchnellOptions{}
+	defaults := defaultOpts.GetDefaultValues()
+	defaultSafetyChecker := defaults["enable_safety_checker"].(*bool)
+
 	return Model{
 		Name:        "flux/schnell",
-		Description: "Quick model for rapid image generation",
+		Description: "Quick model for rapid image generation (FLUX.1 schnell)",
 		PriceUSD:    0.02,
 		Type:        "text2image",
-		HelpDoc:     "Usage: !text2image \nExample: !text2image a beautiful sunset over mountains\n\nParameters:\n• prompt: Text description of the image you want to generate",
+		HelpDoc:     "Usage: !text2image [prompt] [--option value]...\nExample: !text2image a hyperrealistic cat --num_images 2 --image_size square\n\nParameters:\n• prompt: Text description of the image (required)\n• --image_size: Output dimensions (default: landscape_4_3). Options: square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9\n• --num_inference_steps: Number of steps (default: 4)\n• --seed: Specific seed for reproducibility (optional)\n• --num_images: Number of images to generate (default: 1)\n• --enable_safety_checker: Enable safety filter (default: true). Use --enable_safety_checker=false to disable.",
+		Options: &FluxSchnellOptions{
+			ImageSize:           defaults["image_size"].(string),
+			NumInferenceSteps:   defaults["num_inference_steps"].(int),
+			NumImages:           defaults["num_images"].(int),
+			EnableSafetyChecker: defaultSafetyChecker,
+			// Seed and SyncMode default to nil/false
+		},
 	}
 }
 

--- a/pkg/fal/text_speech_models.go
+++ b/pkg/fal/text_speech_models.go
@@ -9,14 +9,34 @@ package fal
 type minimaxTTSModel struct{}
 
 func (m *minimaxTTSModel) Define() Model {
+	// Define default options
+	defaultOpts := &MinimaxTTSOptions{}
+	defaults := defaultOpts.GetDefaultValues()
+	// Extract potentially nil defaults safely
+	var defaultSpeed *float64
+	if v, ok := defaults["speed"].(*float64); ok {
+		defaultSpeed = v
+	}
+	var defaultVol *float64
+	if v, ok := defaults["vol"].(*float64); ok {
+		defaultVol = v
+	}
+
 	return Model{
 		Name:        "minimax-tts/text-to-speech",
 		Description: "Text-to-speech model for converting text to audio. $0.10 per 1000 characters",
 		PriceUSD:    0.10,
 		Type:        "text2speech",
-		HelpDoc:     "Usage: !text2speech [voice_id] [text]\nExample: !text2speech Wise_Woman Hello, how are you today?\n\nParameters:\n• voice_id: Optional voice ID (defaults to Wise_Woman)\n• text: Text to convert to speech\n\nAvailable Voices:\n• Wise_Woman, Friendly_Person, Inspirational_girl\n• Deep_Voice_Man, Calm_Woman, Casual_Guy\n• Lively_Girl, Patient_Man, Young_Knight\n• Determined_Man, Lovely_Girl, Decent_Boy\n• Imposing_Manner, Elegant_Man, Abbess\n• Sweet_Girl_2, Exuberant_Girl",
-		// Note: No specific options struct defined for this model in the original code.
-		Options: nil,
+		HelpDoc:     "Usage: !text2speech [voice_id] [text] [--option value]...\nExample: !text2speech Wise_Woman Hello --speed 0.8 --format flac\n\nParameters:\n• voice_id: Optional voice ID (defaults to Wise_Woman). See list below.\n• text: Text to convert to speech (required)\n• --speed: Speech speed (0.5-2.0, default: 1.0)\n• --vol: Volume (0-10, default: 1.0)\n• --pitch: Voice pitch (-12 to 12, optional)\n• --emotion: happy, sad, angry, fearful, disgusted, surprised, neutral (optional)\n• --sample_rate: 8000, 16000, 22050, 24000, 32000, 44100 (default: 32000)\n• --bitrate: 32000, 64000, 128000, 256000 (default: 128000)\n• --format: mp3, pcm, flac (default: mp3)\n• --channel: 1 (mono), 2 (stereo) (default: 1)\n\nAvailable Voices:\n• Wise_Woman, Friendly_Person, Inspirational_girl\n• Deep_Voice_Man, Calm_Woman, Casual_Guy\n• Lively_Girl, Patient_Man, Young_Knight\n• Determined_Man, Lovely_Girl, Decent_Boy\n• Imposing_Manner, Elegant_Man, Abbess\n• Sweet_Girl_2, Exuberant_Girl",
+		Options: &MinimaxTTSOptions{
+			Speed:      defaultSpeed,
+			Vol:        defaultVol,
+			SampleRate: defaults["sample_rate"].(string),
+			Bitrate:    defaults["bitrate"].(string),
+			Format:     defaults["format"].(string),
+			Channel:    defaults["channel"].(string),
+			// Pitch and Emotion default to nil/""
+		},
 	}
 }
 

--- a/pkg/fal/types.go
+++ b/pkg/fal/types.go
@@ -102,6 +102,176 @@ func (o *KlingVideoOptions) Validate() error {
 	return nil
 }
 
+// FluxSchnellOptions represents the options available for the fal-ai/flux/schnell model
+type FluxSchnellOptions struct {
+	ImageSize           string `json:"image_size,omitempty"`            // square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9
+	NumInferenceSteps   int    `json:"num_inference_steps,omitempty"`   // Default: 4
+	Seed                *int   `json:"seed,omitempty"`                  // Optional seed
+	SyncMode            bool   `json:"sync_mode,omitempty"`             // Default: false
+	NumImages           int    `json:"num_images,omitempty"`            // Default: 1
+	EnableSafetyChecker *bool  `json:"enable_safety_checker,omitempty"` // Default: true
+}
+
+// GetDefaultValues returns the default values for Flux Schnell options
+func (o *FluxSchnellOptions) GetDefaultValues() map[string]interface{} {
+	defaultSafetyChecker := true
+	return map[string]interface{}{
+		"image_size":            "landscape_4_3",
+		"num_inference_steps":   4,
+		"num_images":            1,
+		"enable_safety_checker": &defaultSafetyChecker, // Use pointer for default true bool
+		// seed and sync_mode default to nil/false implicitly
+	}
+}
+
+// Validate validates the Flux Schnell options
+func (o *FluxSchnellOptions) Validate() error {
+	validImageSizes := map[string]bool{
+		"square_hd":      true,
+		"square":         true,
+		"portrait_4_3":   true,
+		"portrait_16_9":  true,
+		"landscape_4_3":  true,
+		"landscape_16_9": true,
+	}
+
+	if o.ImageSize != "" && !validImageSizes[o.ImageSize] {
+		// TODO: Add support for {width, height} object validation if needed
+		return fmt.Errorf("invalid image_size: %s (must be one of: square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9)", o.ImageSize)
+	}
+	if o.NumInferenceSteps < 0 {
+		return fmt.Errorf("num_inference_steps cannot be negative: %d", o.NumInferenceSteps)
+	}
+	if o.NumImages < 0 {
+		return fmt.Errorf("num_images cannot be negative: %d", o.NumImages)
+	}
+
+	return nil
+}
+
+// FluxProV1_1Options represents the options available for the fal-ai/flux-pro/v1.1 model
+type FluxProV1_1Options struct {
+	ImageSize           string `json:"image_size,omitempty"`            // square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9
+	Seed                *int   `json:"seed,omitempty"`                  // Optional seed
+	SyncMode            bool   `json:"sync_mode,omitempty"`             // Default: false
+	NumImages           int    `json:"num_images,omitempty"`            // Default: 1
+	EnableSafetyChecker *bool  `json:"enable_safety_checker,omitempty"` // Default: true
+	SafetyTolerance     string `json:"safety_tolerance,omitempty"`      // Enum: 1, 2, 3, 4, 5, 6. Default: "2"
+	OutputFormat        string `json:"output_format,omitempty"`         // Enum: jpeg, png. Default: "jpeg"
+}
+
+// GetDefaultValues returns the default values for Flux Pro v1.1 options
+func (o *FluxProV1_1Options) GetDefaultValues() map[string]interface{} {
+	defaultSafetyChecker := true
+	return map[string]interface{}{
+		"image_size":            "landscape_4_3",
+		"num_images":            1,
+		"enable_safety_checker": &defaultSafetyChecker,
+		"safety_tolerance":      "2",
+		"output_format":         "jpeg",
+		// seed and sync_mode default to nil/false implicitly
+	}
+}
+
+// Validate validates the Flux Pro v1.1 options
+func (o *FluxProV1_1Options) Validate() error {
+	validImageSizes := map[string]bool{
+		"square_hd":      true,
+		"square":         true,
+		"portrait_4_3":   true,
+		"portrait_16_9":  true,
+		"landscape_4_3":  true,
+		"landscape_16_9": true,
+	}
+	validSafetyTolerances := map[string]bool{
+		"1": true, "2": true, "3": true, "4": true, "5": true, "6": true,
+	}
+	validOutputFormats := map[string]bool{
+		"jpeg": true, "png": true,
+	}
+
+	if o.ImageSize != "" && !validImageSizes[o.ImageSize] {
+		return fmt.Errorf("invalid image_size: %s", o.ImageSize)
+	}
+	if o.NumImages < 0 {
+		return fmt.Errorf("num_images cannot be negative: %d", o.NumImages)
+	}
+	if o.SafetyTolerance != "" && !validSafetyTolerances[o.SafetyTolerance] {
+		return fmt.Errorf("invalid safety_tolerance: %s (must be 1-6)", o.SafetyTolerance)
+	}
+	if o.OutputFormat != "" && !validOutputFormats[o.OutputFormat] {
+		return fmt.Errorf("invalid output_format: %s (must be jpeg or png)", o.OutputFormat)
+	}
+	return nil
+}
+
+// MinimaxTTSOptions represents options for the minimax-tts model.
+type MinimaxTTSOptions struct {
+	// Voice Settings
+	// VoiceID handled in request struct
+	Speed   *float64 `json:"speed,omitempty"`   // 0.5 - 2.0, default 1.0
+	Vol     *float64 `json:"vol,omitempty"`     // 0 - 10, default 1.0
+	Pitch   *int     `json:"pitch,omitempty"`   // -12 - 12, optional
+	Emotion string   `json:"emotion,omitempty"` // happy, sad, etc. optional
+	// Audio Settings
+	SampleRate string `json:"sample_rate,omitempty"` // 8000, 16000, ..., default 32000
+	Bitrate    string `json:"bitrate,omitempty"`     // 32000, 64000, ..., default 128000
+	Format     string `json:"format,omitempty"`      // mp3, pcm, flac, default mp3
+	Channel    string `json:"channel,omitempty"`     // 1 (mono), 2 (stereo), default 1
+}
+
+// GetDefaultValues returns default values for MinimaxTTSOptions.
+func (o *MinimaxTTSOptions) GetDefaultValues() map[string]interface{} {
+	// Define defaults as pointers where applicable to match struct fields
+	defaultSpeed := 1.0
+	defaultVol := 1.0
+	return map[string]interface{}{
+		"speed":       &defaultSpeed,
+		"vol":         &defaultVol,
+		"sample_rate": "32000",
+		"bitrate":     "128000",
+		"format":      "mp3",
+		"channel":     "1",
+		// Pitch and Emotion default to nil/""
+	}
+}
+
+// Validate validates MinimaxTTSOptions.
+func (o *MinimaxTTSOptions) Validate() error {
+	// Voice Settings Validation
+	if o.Speed != nil && (*o.Speed < 0.5 || *o.Speed > 2.0) {
+		return fmt.Errorf("invalid speed: %f (must be between 0.5 and 2.0)", *o.Speed)
+	}
+	if o.Vol != nil && (*o.Vol < 0 || *o.Vol > 10.0) {
+		return fmt.Errorf("invalid vol: %f (must be between 0 and 10)", *o.Vol)
+	}
+	if o.Pitch != nil && (*o.Pitch < -12 || *o.Pitch > 12) {
+		return fmt.Errorf("invalid pitch: %d (must be between -12 and 12)", *o.Pitch)
+	}
+	validEmotions := map[string]bool{"happy": true, "sad": true, "angry": true, "fearful": true, "disgusted": true, "surprised": true, "neutral": true, "": true}
+	if !validEmotions[o.Emotion] {
+		return fmt.Errorf("invalid emotion: %s", o.Emotion)
+	}
+	// Audio Settings Validation
+	validSampleRates := map[string]bool{"8000": true, "16000": true, "22050": true, "24000": true, "32000": true, "44100": true, "": true}
+	if !validSampleRates[o.SampleRate] {
+		return fmt.Errorf("invalid sample_rate: %s", o.SampleRate)
+	}
+	validBitrates := map[string]bool{"32000": true, "64000": true, "128000": true, "256000": true, "": true}
+	if !validBitrates[o.Bitrate] {
+		return fmt.Errorf("invalid bitrate: %s", o.Bitrate)
+	}
+	validFormats := map[string]bool{"mp3": true, "pcm": true, "flac": true, "": true}
+	if !validFormats[o.Format] {
+		return fmt.Errorf("invalid format: %s", o.Format)
+	}
+	validChannels := map[string]bool{"1": true, "2": true, "": true}
+	if !validChannels[o.Channel] {
+		return fmt.Errorf("invalid channel: %s", o.Channel)
+	}
+	return nil
+}
+
 // ModelDefinition is an interface for types that define a Fal.ai model.
 // Implementations of this interface are expected to register themselves
 // using the registerModel function in their init() function.
@@ -119,12 +289,59 @@ type Model struct {
 	Options     ModelOptions // Model-specific options
 }
 
-// ImageRequest represents a request to generate an image
-type ImageRequest struct {
-	Prompt   string
-	Model    string
-	Options  map[string]interface{}
-	Progress ProgressCallback
+// BaseImageRequest represents the base fields for an image generation request
+// (text2image or image2image)
+type BaseImageRequest struct {
+	Prompt   string                 `json:"prompt,omitempty"`    // Optional for image2image
+	ImageURL string                 `json:"image_url,omitempty"` // Required for image2image
+	Model    string                 `json:"-"`                   // Internal use: model name
+	Options  map[string]interface{} `json:"-"`                   // Fallback for generic options
+	Progress ProgressCallback       `json:"-"`                   // Progress callback interface
+}
+
+// GetProgress returns the progress callback
+func (r *BaseImageRequest) GetProgress() ProgressCallback {
+	return r.Progress
+}
+
+// GetOptions returns the options map
+func (r *BaseImageRequest) GetOptions() map[string]interface{} {
+	return r.Options
+}
+
+// FastSDXLRequest represents a request to generate an image using fast-sdxl
+type FastSDXLRequest struct {
+	BaseImageRequest
+	NumImages int `json:"num_images,omitempty"` // Optional: Number of images to generate
+}
+
+// GhiblifyRequest represents a request to transform an image using ghiblify
+type GhiblifyRequest struct {
+	BaseImageRequest // Requires ImageURL to be set
+	// No specific options for Ghiblify identified yet
+}
+
+// FluxSchnellRequest represents a request to generate an image using fal-ai/flux/schnell
+type FluxSchnellRequest struct {
+	BaseImageRequest
+	ImageSize           string `json:"image_size,omitempty"`
+	NumInferenceSteps   int    `json:"num_inference_steps,omitempty"`
+	Seed                *int   `json:"seed,omitempty"`
+	SyncMode            bool   `json:"sync_mode,omitempty"`
+	NumImages           int    `json:"num_images,omitempty"`
+	EnableSafetyChecker *bool  `json:"enable_safety_checker,omitempty"`
+}
+
+// FluxProV1_1Request represents a request for the fal-ai/flux-pro/v1.1 model
+type FluxProV1_1Request struct {
+	BaseImageRequest
+	ImageSize           string `json:"image_size,omitempty"`
+	Seed                *int   `json:"seed,omitempty"`
+	SyncMode            bool   `json:"sync_mode,omitempty"`
+	NumImages           int    `json:"num_images,omitempty"`
+	EnableSafetyChecker *bool  `json:"enable_safety_checker,omitempty"`
+	SafetyTolerance     string `json:"safety_tolerance,omitempty"`
+	OutputFormat        string `json:"output_format,omitempty"`
 }
 
 // ImageResponse represents the response from an image generation request
@@ -138,15 +355,40 @@ type ImageResponse struct {
 	NSFW        bool      `json:"nsfw"`
 	CreatedAt   time.Time `json:"created_at"`
 	CompletedAt time.Time `json:"completed_at"`
+	Seed        int       `json:"seed"` // Seed used for the generation
 }
 
-// SpeechRequest represents a request to generate speech
-type SpeechRequest struct {
-	Model    string // Name of the text-to-speech model to use
-	Text     string
-	VoiceID  string // Specific to models like minimax-tts
-	Options  map[string]interface{}
-	Progress ProgressCallback
+// BaseSpeechRequest represents the base fields for a speech generation request
+type BaseSpeechRequest struct {
+	Model    string                 `json:"-"` // Internal use: model name
+	Text     string                 `json:"text"`
+	Options  map[string]interface{} `json:"-"` // Fallback for generic options
+	Progress ProgressCallback       `json:"-"` // Progress callback interface
+}
+
+// GetProgress returns the progress callback
+func (r *BaseSpeechRequest) GetProgress() ProgressCallback {
+	return r.Progress
+}
+
+// GetOptions returns the options map
+func (r *BaseSpeechRequest) GetOptions() map[string]interface{} {
+	return r.Options
+}
+
+// MinimaxTTSRequest represents a request to generate speech using minimax-tts
+type MinimaxTTSRequest struct {
+	BaseSpeechRequest
+	VoiceID string `json:"-"` // Not sent directly, part of voice_setting
+	// Mirrored Options for convenience
+	Speed      *float64 `json:"-"`
+	Vol        *float64 `json:"-"`
+	Pitch      *int     `json:"-"`
+	Emotion    string   `json:"-"`
+	SampleRate string   `json:"-"`
+	Bitrate    string   `json:"-"`
+	Format     string   `json:"-"`
+	Channel    string   `json:"-"`
 }
 
 // AudioResponse represents the response from a speech generation request
@@ -240,4 +482,176 @@ type Error struct {
 
 func (e *Error) Error() string {
 	return e.Message
+}
+
+// HiDreamOptions represents common options for fal-ai/hidream models
+type HiDreamOptions struct {
+	NegativePrompt      string   `json:"negative_prompt,omitempty"`       // Default: ""
+	ImageSize           string   `json:"image_size,omitempty"`            // Default: "square_hd"
+	NumInferenceSteps   *int     `json:"num_inference_steps,omitempty"`   // Default: 50
+	Seed                *int     `json:"seed,omitempty"`                  // Optional seed
+	GuidanceScale       *float64 `json:"guidance_scale,omitempty"`        // Default: 5.0
+	SyncMode            bool     `json:"sync_mode,omitempty"`             // Default: false
+	NumImages           int      `json:"num_images,omitempty"`            // Default: 1
+	EnableSafetyChecker *bool    `json:"enable_safety_checker,omitempty"` // Default: true
+	OutputFormat        string   `json:"output_format,omitempty"`         // Default: "jpeg"
+}
+
+// GetDefaultValues returns default values for HiDream options
+func (o *HiDreamOptions) GetDefaultValues() map[string]interface{} {
+	defaultNumSteps := 50
+	defaultGuidanceScale := 5.0
+	defaultSafetyChecker := true
+	return map[string]interface{}{
+		"negative_prompt":       "",
+		"image_size":            "square_hd", // Defaulting to 1024x1024
+		"num_inference_steps":   &defaultNumSteps,
+		"guidance_scale":        &defaultGuidanceScale,
+		"num_images":            1,
+		"enable_safety_checker": &defaultSafetyChecker,
+		"output_format":         "jpeg",
+	}
+}
+
+// Validate validates HiDream options
+func (o *HiDreamOptions) Validate() error {
+	validImageSizes := map[string]bool{
+		"square_hd": true, "square": true, "portrait_4_3": true,
+		"portrait_16_9": true, "landscape_4_3": true, "landscape_16_9": true,
+	}
+	validOutputFormats := map[string]bool{"jpeg": true, "png": true, "": true}
+
+	if o.ImageSize != "" && !validImageSizes[o.ImageSize] {
+		return fmt.Errorf("invalid image_size: %s", o.ImageSize)
+	}
+	if o.NumInferenceSteps != nil && *o.NumInferenceSteps <= 0 {
+		return fmt.Errorf("num_inference_steps must be positive: %d", *o.NumInferenceSteps)
+	}
+	if o.GuidanceScale != nil && *o.GuidanceScale < 0 {
+		return fmt.Errorf("guidance_scale cannot be negative: %f", *o.GuidanceScale)
+	}
+	if o.NumImages < 0 {
+		return fmt.Errorf("num_images cannot be negative: %d", o.NumImages)
+	}
+	if o.OutputFormat != "" && !validOutputFormats[o.OutputFormat] {
+		return fmt.Errorf("invalid output_format: %s", o.OutputFormat)
+	}
+	return nil
+}
+
+// HiDreamI1FullRequest represents a request for the fal-ai/hidream-i1-full model
+type HiDreamI1FullRequest struct {
+	BaseImageRequest
+	NegativePrompt      string   `json:"negative_prompt,omitempty"`
+	ImageSize           string   `json:"image_size,omitempty"`
+	NumInferenceSteps   *int     `json:"num_inference_steps,omitempty"`
+	Seed                *int     `json:"seed,omitempty"`
+	GuidanceScale       *float64 `json:"guidance_scale,omitempty"`
+	SyncMode            bool     `json:"sync_mode,omitempty"`
+	NumImages           int      `json:"num_images,omitempty"`
+	EnableSafetyChecker *bool    `json:"enable_safety_checker,omitempty"`
+	OutputFormat        string   `json:"output_format,omitempty"`
+}
+
+// HiDreamI1DevRequest represents a request for the fal-ai/hidream-i1-dev model
+type HiDreamI1DevRequest struct {
+	HiDreamI1FullRequest // Assuming same params as full
+}
+
+// HiDreamI1FastRequest represents a request for the fal-ai/hidream-i1-fast model
+type HiDreamI1FastRequest struct {
+	HiDreamI1FullRequest // Assuming same params as full
+}
+
+// FluxProV1_1UltraOptions represents options for fal-ai/flux-pro/v1.1-ultra
+type FluxProV1_1UltraOptions struct {
+	Seed                *int   `json:"seed,omitempty"`
+	SyncMode            bool   `json:"sync_mode,omitempty"`
+	NumImages           int    `json:"num_images,omitempty"`
+	EnableSafetyChecker *bool  `json:"enable_safety_checker,omitempty"`
+	SafetyTolerance     string `json:"safety_tolerance,omitempty"`
+	OutputFormat        string `json:"output_format,omitempty"`
+	AspectRatio         string `json:"aspect_ratio,omitempty"` // Different from image_size
+	Raw                 *bool  `json:"raw,omitempty"`
+}
+
+// GetDefaultValues returns default values for Flux Pro v1.1 Ultra options
+func (o *FluxProV1_1UltraOptions) GetDefaultValues() map[string]interface{} {
+	defaultSafetyChecker := true
+	defaultRaw := false
+	return map[string]interface{}{
+		"num_images":            1,
+		"enable_safety_checker": &defaultSafetyChecker,
+		"safety_tolerance":      "2",
+		"output_format":         "jpeg",
+		"aspect_ratio":          "16:9",
+		"raw":                   &defaultRaw,
+	}
+}
+
+// Validate validates Flux Pro v1.1 Ultra options
+func (o *FluxProV1_1UltraOptions) Validate() error {
+	validSafetyTolerances := map[string]bool{"1": true, "2": true, "3": true, "4": true, "5": true, "6": true, "": true}
+	validOutputFormats := map[string]bool{"jpeg": true, "png": true, "": true}
+	validAspectRatios := map[string]bool{
+		"21:9": true, "16:9": true, "4:3": true, "3:2": true, "1:1": true,
+		"2:3": true, "3:4": true, "9:16": true, "9:21": true, "": true,
+	}
+
+	if o.NumImages < 0 {
+		return fmt.Errorf("num_images cannot be negative: %d", o.NumImages)
+	}
+	if o.SafetyTolerance != "" && !validSafetyTolerances[o.SafetyTolerance] {
+		return fmt.Errorf("invalid safety_tolerance: %s (must be 1-6)", o.SafetyTolerance)
+	}
+	if o.OutputFormat != "" && !validOutputFormats[o.OutputFormat] {
+		return fmt.Errorf("invalid output_format: %s (must be jpeg or png)", o.OutputFormat)
+	}
+	if o.AspectRatio != "" && !validAspectRatios[o.AspectRatio] {
+		return fmt.Errorf("invalid aspect_ratio: %s", o.AspectRatio)
+	}
+	return nil
+}
+
+// CartoonifyOptions represents options for the cartoonify model.
+type CartoonifyOptions struct {
+	// No specific options identified yet
+}
+
+func (o *CartoonifyOptions) GetDefaultValues() map[string]interface{} {
+	return make(map[string]interface{})
+}
+func (o *CartoonifyOptions) Validate() error { return nil }
+
+// StarVectorOptions represents options for the star-vector model.
+type StarVectorOptions struct {
+	// No specific options identified yet
+}
+
+func (o *StarVectorOptions) GetDefaultValues() map[string]interface{} {
+	return make(map[string]interface{})
+}
+func (o *StarVectorOptions) Validate() error { return nil }
+
+// FluxProV1_1UltraRequest represents a request for fal-ai/flux-pro/v1.1-ultra
+type FluxProV1_1UltraRequest struct {
+	BaseImageRequest
+	Seed                *int   `json:"seed,omitempty"`
+	SyncMode            bool   `json:"sync_mode,omitempty"`
+	NumImages           int    `json:"num_images,omitempty"`
+	EnableSafetyChecker *bool  `json:"enable_safety_checker,omitempty"`
+	SafetyTolerance     string `json:"safety_tolerance,omitempty"`
+	OutputFormat        string `json:"output_format,omitempty"`
+	AspectRatio         string `json:"aspect_ratio,omitempty"`
+	Raw                 *bool  `json:"raw,omitempty"`
+}
+
+// CartoonifyRequest represents a request for the cartoonify model
+type CartoonifyRequest struct {
+	BaseImageRequest // Requires ImageURL
+}
+
+// StarVectorRequest represents a request for the star-vector model
+type StarVectorRequest struct {
+	BaseImageRequest // Requires ImageURL
 }


### PR DESCRIPTION
Refactor: Use specific structs for Fal model requests and options

Introduces a consistent pattern for handling model-specific parameters
across image, video, and speech generation in the `pkg/fal` client and
internal services.

- Replaces generic requests with base + specific structs (e.g.,
  `FluxSchnellRequest`, `MinimaxTTSRequest`, `KlingVideoRequest`).
- Defines specific `Options` structs (e.g., `FluxSchnellOptions`)
  implementing `ModelOptions` for validation and defaults.
- Updates model definitions to associate specific `Options`.
- Refactors FAL client methods (`GenerateImage`, etc.) to handle
  specific request types via type switches and perform validation.
- Adds specific option handling for flux, minimax-tts, hidream,
  cartoonify, star-vector, etc. models based on documentation.
- Refactors command argument parsing (`text2image`, `text2speech`,
  video commands) using helpers/parsers to extract specific options.
- Introduces `internal/speech` package with `SpeechService`.
- Updates command initialization to inject services.
- Aligns option validation within the FAL client layer.
- Implements correct billing for multiple image generation (`num_images`).
- Adds seed reporting for image generation.
- Switches speech delivery from base64 embed to `SendFile`.
- Updates `pkg/fal/README.md` examples.