### PR TITLE
ensure billing only on succesful image generation

### DIFF
--- a/internal/commands/image2image.go
+++ b/internal/commands/image2image.go
@@ -59,17 +59,11 @@ func Image2ImageCommand(dbManager *database.DBManager, imageService *image.Image
 				return bot.SendPM(ctx, pm.Nick, "Please provide a valid http:// or https:// URL for the image.")
 			}
 
-			// Create Fal.ai client
-			client := fal.NewClient(cfg.ExtraConfig["falapikey"], fal.WithDebug(debug))
-
 			// Get model configuration
 			model, exists := faladapter.GetCurrentModel("image2image")
 			if !exists {
 				return fmt.Errorf("no default model found for image2image")
 			}
-
-			// Create image service
-			imageService := image.NewImageService(client, dbManager, bot, debug)
 
 			// Create progress callback
 			progress := NewCommandProgressCallback(bot, pm.Nick, "image2image")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 
 // CheckAndUpdateConfig checks if required configuration settings are present
 // and prompts the user to enter them if they're missing.
+// It also sets default values for optional settings like billing_enabled.
 func CheckAndUpdateConfig(cfg *config.BotConfig, appRoot string) error {
 	// Ensure the directory exists first
 	if err := os.MkdirAll(appRoot, 0755); err != nil {
@@ -51,8 +52,82 @@ func CheckAndUpdateConfig(cfg *config.BotConfig, appRoot string) error {
 		}
 	}
 
+	// Check for billingenabled setting
+	if _, exists := cfg.ExtraConfig["billingenabled"]; !exists {
+		// Prompt user interactively if setting is missing
+		reader := bufio.NewReader(os.Stdin)
+		var billingEnabledStr string
+		for {
+			fmt.Print("Do you want to enable billing? (yes/no): ")
+			input, err := reader.ReadString('\n')
+			if err != nil {
+				// Handle potential read error (e.g., EOF)
+				fmt.Printf("\nError reading input: %v. Defaulting billing to DISABLED.\n", err)
+				billingEnabledStr = "false"
+				break
+			}
+			input = strings.ToLower(strings.TrimSpace(input))
+
+			if input == "yes" || input == "y" {
+				billingEnabledStr = "true"
+				break
+			} else if input == "no" || input == "n" {
+				billingEnabledStr = "false"
+				break
+			} else {
+				fmt.Println("Invalid input. Please enter 'yes' or 'no'.")
+			}
+		}
+
+		// Store the chosen setting in the config map
+		cfg.ExtraConfig["billingenabled"] = billingEnabledStr
+
+		// Append the setting to the config file
+		configPath := filepath.Join(appRoot, "braibot.conf")
+		f, err := os.OpenFile(configPath, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			// Log error but continue, config map has the value
+			fmt.Printf("WARN: Failed to open config file to append billingenabled setting: %v\n", err)
+		} else {
+			if _, err := f.WriteString(fmt.Sprintf("billingenabled=%s\n", billingEnabledStr)); err != nil {
+				fmt.Printf("WARN: Failed to write billingenabled setting to config file: %v\n", err)
+			}
+			f.Close() // Close file only if opened successfully
+		}
+
+	} else {
+		// Validate existing setting
+		val := strings.ToLower(strings.TrimSpace(cfg.ExtraConfig["billingenabled"]))
+		if val != "true" && val != "false" {
+			fmt.Printf("Invalid value '%s' for billingenabled found in config, defaulting to true.\n", cfg.ExtraConfig["billingenabled"])
+			cfg.ExtraConfig["billingenabled"] = "true"
+			// Optionally write the default back to the config file
+			// writeDefaultBillingSetting(appRoot, "true") // Need a function that takes value
+		} else {
+			// Store the validated, lowercased value back
+			cfg.ExtraConfig["billingenabled"] = val
+		}
+	}
+
 	return nil
 }
+
+// Optional: Helper function to write the default billing setting if needed
+/*
+func writeDefaultBillingSetting(appRoot string, value string) {
+	configPath := filepath.Join(appRoot, "braibot.conf")
+	f, err := os.OpenFile(configPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Printf("WARN: Failed to open config file to write default billingenabled: %v\n", err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(fmt.Sprintf("billingenabled=%s\n", value)); err != nil {
+		fmt.Printf("WARN: Failed to write default billingenabled to config file: %v\n", err)
+	}
+}
+*/
 
 // TestAssetServerCredentials tests if the asset server credentials are valid
 func TestAssetServerCredentials(serverURL, apiKey string) error {

--- a/internal/image/service.go
+++ b/internal/image/service.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/companyzero/bisonrelay/clientrpc/types"
+	// Keep for PM type reference if needed indirectly
 	"github.com/karamble/braibot/internal/database"
 	"github.com/karamble/braibot/internal/faladapter"
 	"github.com/karamble/braibot/internal/utils"
@@ -18,82 +18,79 @@ import (
 
 // ImageService handles image generation
 type ImageService struct {
-	client    *fal.Client
-	dbManager *database.DBManager
-	bot       *kit.Bot
-	debug     bool
+	client         *fal.Client
+	dbManager      *database.DBManager
+	bot            *kit.Bot
+	debug          bool
+	billingEnabled bool // Added billing enabled flag
 }
 
 // NewImageService creates a new ImageService
-func NewImageService(client *fal.Client, dbManager *database.DBManager, bot *kit.Bot, debug bool) *ImageService {
+func NewImageService(client *fal.Client, dbManager *database.DBManager, bot *kit.Bot, debug bool, billingEnabled bool) *ImageService {
 	return &ImageService{
-		client:    client,
-		dbManager: dbManager,
-		bot:       bot,
-		debug:     debug,
+		client:         client,
+		dbManager:      dbManager,
+		bot:            bot,
+		debug:          debug,
+		billingEnabled: billingEnabled, // Store the flag
 	}
 }
 
-// GenerateImage generates an image based on the request
+// GenerateImage generates an image based on the request, handling billing after successful result sending.
 func (s *ImageService) GenerateImage(ctx context.Context, req *ImageRequest) (*ImageResult, error) {
 	// 1. Validate request
 	if err := s.validateRequest(req); err != nil {
 		return &ImageResult{Success: false, Error: err}, err
 	}
 
-	// 2. Calculate expected cost and check balance
+	// 2. Calculate expected cost and CHECK balance (don't deduct yet)
 	numImagesToRequest := req.NumImages
 	if numImagesToRequest <= 0 {
 		numImagesToRequest = 1 // Default to 1 if not specified or invalid
 	}
 	totalExpectedCostUSD := req.PriceUSD * float64(numImagesToRequest)
 
-	pm := types.ReceivedPM{
-		Nick: req.UserNick,
-		Uid:  req.UserID[:],
+	// Check balance, passing the billingEnabled flag
+	hasSufficientBalance, requiredDCR, currentBalanceDCR, insufErrMsg, checkErr := utils.CheckBalance(ctx, s.dbManager, req.UserID[:], totalExpectedCostUSD, s.debug, s.billingEnabled)
+	if checkErr != nil {
+		// Critical error during balance check
+		err := fmt.Errorf("failed during balance check: %v", checkErr)
+		return &ImageResult{Success: false, Error: err}, err
 	}
-	billingResult, billingErr := utils.CheckAndProcessBilling(ctx, s.bot, s.dbManager, pm, totalExpectedCostUSD, s.debug)
-	if billingErr != nil {
-		return &ImageResult{Success: false, Error: billingErr}, billingErr
-	}
-	if !billingResult.Success {
-		return &ImageResult{Success: false, Error: fmt.Errorf(billingResult.ErrorMessage)}, nil
+	if !hasSufficientBalance {
+		// Insufficient funds (only happens if billing is enabled)
+		return &ImageResult{Success: false, Error: fmt.Errorf(insufErrMsg)}, nil
 	}
 
-	// 3. Send initial message
-	s.bot.SendPM(ctx, req.UserNick, "Processing your request.")
+	// Inform user about processing (adjust message based on billing)
+	var infoMsg string
+	if s.billingEnabled {
+		infoMsg = fmt.Sprintf("Request cost: $%.2f USD (%.8f DCR). Your balance: %.8f DCR. Processing...", totalExpectedCostUSD, requiredDCR, currentBalanceDCR)
+	} else {
+		infoMsg = "Processing your request (billing disabled)..."
+	}
+	s.bot.SendPM(ctx, req.UserNick, infoMsg)
 
 	// 4. Create the appropriate FAL request object using the helper function
 	falReq, err := createFalImageRequest(req, numImagesToRequest)
 	if err != nil {
 		// Handle error from request creation (e.g., unsupported model)
-		// Attempt to refund if billing was successful but we can't create the request
-		// if refundErr := utils.RefundBilling(ctx, s.bot, pm, billingResult); refundErr != nil {
-		// 	s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to process refund after request creation error: %v", refundErr))
-		// }
-		return &ImageResult{Success: false, Error: err}, err
+		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Error creating generation request: %v", err))
+		return &ImageResult{Success: false, Error: err}, err // No billing occurred
 	}
 
 	// 5. Generate image using the created request
 	imageResp, genErr := s.client.GenerateImage(ctx, falReq)
 	if genErr != nil {
-		// Attempt to refund if billing was successful but generation failed
-		// Note: Refund logic might need adjustment based on CheckAndProcessBilling behavior
-		// if err := utils.RefundBilling(ctx, s.bot, pm, billingResult); err != nil {
-		// 	 s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to process refund after generation error: %v", err))
-		// }
-		return &ImageResult{Success: false, Error: genErr}, genErr
+		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Image generation failed: %v", genErr))
+		return &ImageResult{Success: false, Error: genErr}, genErr // No billing occurred
 	}
 
 	// 6. Check if the image URL is empty - check if *any* images were returned
 	if len(imageResp.Images) == 0 {
 		genErr = fmt.Errorf("API did not return any images")
-		// Attempt to refund if billing was successful but generation failed
-		// Note: Refund logic might need adjustment based on CheckAndProcessBilling behavior
-		// if err := utils.RefundBilling(ctx, s.bot, pm, billingResult); err != nil {
-		// 	 s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to process refund after generation error: %v", err))
-		// }
-		return &ImageResult{Success: false, Error: genErr}, genErr
+		s.bot.SendPM(ctx, req.UserNick, genErr.Error())
+		return &ImageResult{Success: false, Error: genErr}, genErr // No billing occurred
 	}
 
 	// 7. Send the image(s) - loop through results
@@ -109,46 +106,20 @@ func (s *ImageService) GenerateImage(ctx context.Context, req *ImageRequest) (*I
 		contentType := img.ContentType
 		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Sending image %d of %d...", i+1, numImagesGenerated))
 
+		var sendErr error
 		if strings.Contains(contentType, "svg") || !strings.HasPrefix(contentType, "image/") {
 			// For SVG or non-standard image formats, use SendFile
-			if err := utils.SendFileToUser(ctx, s.bot, req.UserNick, img.URL, "image", contentType); err != nil {
-				s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to send image %d/%d: %v", i+1, numImagesGenerated, err))
-				// Optionally continue to try sending other images
-			} else {
-				successfullySentCount++
-			}
+			sendErr = utils.SendFileToUser(ctx, s.bot, req.UserNick, img.URL, "image", contentType)
 		} else {
 			// For standard image formats, use PM embed
-			// Fetch the image data
-			imgDataResp, err := http.Get(img.URL)
-			if err != nil {
-				s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to fetch image %d/%d: %v", i+1, numImagesGenerated, err))
-				continue // Skip this image
-			}
-			defer imgDataResp.Body.Close()
+			sendErr = sendEmbeddedImage(ctx, s.bot, req, img, i, numImagesGenerated)
+		}
 
-			imageData, err := io.ReadAll(imgDataResp.Body)
-			if err != nil {
-				s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to read image data %d/%d: %v", i+1, numImagesGenerated, err))
-				continue // Skip this image
-			}
-
-			// Encode the image data to base64
-			encodedImage := base64.StdEncoding.EncodeToString(imageData)
-
-			// Create the message with embedded image
-			message := fmt.Sprintf("--embed[alt=%s image %d/%d,type=%s,data=%s]--",
-				req.ModelName,
-				i+1,
-				numImagesGenerated,
-				contentType,
-				encodedImage)
-			if err := s.bot.SendPM(ctx, req.UserNick, message); err != nil {
-				s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to send embedded image %d/%d: %v", i+1, numImagesGenerated, err))
-				// Optionally continue
-			} else {
-				successfullySentCount++
-			}
+		if sendErr != nil {
+			s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to send image %d/%d: %v", i+1, numImagesGenerated, sendErr))
+			// Optionally continue to try sending other images
+		} else {
+			successfullySentCount++
 		}
 	}
 
@@ -160,30 +131,102 @@ func (s *ImageService) GenerateImage(ctx context.Context, req *ImageRequest) (*I
 		}
 	}
 
-	// 8. Send final confirmation and billing info
+	// 8. Perform Billing *only if* enabled and at least one image was sent successfully
+	var chargedDCR float64
+	var finalBalanceDCR float64 = currentBalanceDCR // Start with the balance known before potential deduction
+	var billingAttempted bool = false
+	var billingSucceeded bool = false
+
+	if s.billingEnabled && successfullySentCount > 0 {
+		billingAttempted = true
+		deductChargedDCR, deductNewBalance, deductErr := utils.DeductBalance(ctx, s.dbManager, req.UserID[:], totalExpectedCostUSD, s.debug, s.billingEnabled)
+		if deductErr != nil {
+			// Log the error and inform the user
+			s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Error processing payment after sending results: %v. Please contact support.", deductErr))
+			// Use the balance known before the failed deduction attempt
+			finalBalanceDCR = currentBalanceDCR
+		} else {
+			billingSucceeded = true
+			chargedDCR = deductChargedDCR
+			finalBalanceDCR = deductNewBalance
+		}
+	} else if !s.billingEnabled {
+		// fmt.Printf("INFO: Billing is disabled. No charge applied for user %s.\n", req.UserNick) // Already Removed
+	} else {
+		// Billing enabled, but no images sent successfully
+		// fmt.Printf("INFO: No images sent successfully for user %s. No billing occurred.\n", req.UserNick) // Removed
+	}
+
+	// 9. Send final confirmation
 	finalMessage := fmt.Sprintf("Finished processing request. Sent %d of %d generated image(s).\n\n", successfullySentCount, numImagesGenerated)
 
-	// Append billing info (using data from the initial check)
-	finalMessage += fmt.Sprintf("💰 Billing Information:\n• Charged: %.8f DCR ($%.2f USD)\n• Remaining Balance: %.8f DCR",
-		billingResult.ChargedDCR,
-		billingResult.ChargedUSD,
-		billingResult.NewBalance)
+	if s.billingEnabled {
+		if billingAttempted && billingSucceeded {
+			finalMessage += fmt.Sprintf("💰 Billing Information:\n• Charged: %.8f DCR ($%.2f USD)\n• New Balance: %.8f DCR",
+				chargedDCR,
+				totalExpectedCostUSD, // Using the original cost USD for consistency
+				finalBalanceDCR)
+		} else if billingAttempted && !billingSucceeded {
+			// Images sent, but billing failed
+			finalMessage += fmt.Sprintf("⚠️ Billing failed after sending results. Your balance remains %.8f DCR. Please contact support.", finalBalanceDCR)
+		} else {
+			// Billing enabled, but no charge was applied (e.g., no images sent)
+			finalMessage += fmt.Sprintf("No charge was applied. Your balance remains %.8f DCR.", finalBalanceDCR)
+		}
+	} else {
+		// Billing is disabled
+		finalMessage += "Billing is disabled. No charge was applied."
+	}
 
 	if err := s.bot.SendPM(ctx, req.UserNick, finalMessage); err != nil {
 		// Log error, but don't fail the whole operation just because the final message failed
-		fmt.Printf("ERROR: Failed to send final billing message to %s: %v\n", req.UserNick, err)
+		// fmt.Printf("ERROR: Failed to send final confirmation message to %s: %v\n", req.UserNick, err) // Removed
 	}
 
 	// Return success if at least one image was generated, using the last URL
 	if numImagesGenerated > 0 {
+		// Indicate overall success based on generation, even if sending/billing had issues
+		// The final message informs the user about those issues.
 		return &ImageResult{
 			ImageURL: lastSentImageURL, // Return the URL of the last image generated/sent
-			Success:  true,
+			Success:  true,             // Represents successful generation from the API
 		}, nil
 	} else {
 		// This case should ideally be caught earlier, but as a fallback
 		return &ImageResult{Success: false, Error: fmt.Errorf("no images were generated successfully")}, nil
 	}
+}
+
+// sendEmbeddedImage fetches, encodes, and sends an image embedded in a PM.
+func sendEmbeddedImage(ctx context.Context, bot *kit.Bot, req *ImageRequest, img fal.ImageOutput, index, total int) error {
+	// Fetch the image data
+	imgDataResp, err := http.Get(img.URL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch image %d/%d: %w", index+1, total, err)
+	}
+	defer imgDataResp.Body.Close()
+
+	if imgDataResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to fetch image %d/%d: status %s", index+1, total, imgDataResp.Status)
+	}
+
+	imageData, err := io.ReadAll(imgDataResp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read image data %d/%d: %w", index+1, total, err)
+	}
+
+	// Encode the image data to base64
+	encodedImage := base64.StdEncoding.EncodeToString(imageData)
+
+	// Create the message with embedded image
+	message := fmt.Sprintf("--embed[alt=%s image %d/%d,type=%s,data=%s]--",
+		req.ModelName,
+		index+1,
+		total,
+		img.ContentType,
+		encodedImage)
+
+	return bot.SendPM(ctx, req.UserNick, message)
 }
 
 // Helper function to safely dereference optional int pointers

--- a/internal/speech/service.go
+++ b/internal/speech/service.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/companyzero/bisonrelay/clientrpc/types"
+	// "github.com/companyzero/bisonrelay/clientrpc/types" // Only needed for old billing call
 	"github.com/karamble/braibot/internal/database"
 	"github.com/karamble/braibot/internal/utils"
 	"github.com/karamble/braibot/pkg/fal"
@@ -16,76 +16,134 @@ import (
 
 // SpeechService handles speech generation
 type SpeechService struct {
-	client    *fal.Client
-	dbManager *database.DBManager
-	bot       *kit.Bot
-	debug     bool
+	client         *fal.Client
+	dbManager      *database.DBManager
+	bot            *kit.Bot
+	debug          bool
+	billingEnabled bool // Added billing enabled flag
 }
 
 // NewSpeechService creates a new SpeechService
-func NewSpeechService(client *fal.Client, dbManager *database.DBManager, bot *kit.Bot, debug bool) *SpeechService {
+func NewSpeechService(client *fal.Client, dbManager *database.DBManager, bot *kit.Bot, debug bool, billingEnabled bool) *SpeechService {
 	return &SpeechService{
-		client:    client,
-		dbManager: dbManager,
-		bot:       bot,
-		debug:     debug,
+		client:         client,
+		dbManager:      dbManager,
+		bot:            bot,
+		debug:          debug,
+		billingEnabled: billingEnabled, // Store the flag
 	}
 }
 
-// GenerateSpeech generates speech based on the internal request
+// GenerateSpeech generates speech based on the internal request, handling billing conditionally.
 func (s *SpeechService) GenerateSpeech(ctx context.Context, req *SpeechRequest) (*SpeechResult, error) {
-	// 1. Check balance (No validation needed here as options are simple for now)
-	pm := types.ReceivedPM{
-		Nick: req.UserNick,
-		Uid:  req.UserID[:],
-	}
-	billingResult, billingErr := utils.CheckAndProcessBilling(ctx, s.bot, s.dbManager, pm, req.PriceUSD, s.debug)
-	if billingErr != nil {
-		return &SpeechResult{Success: false, Error: billingErr}, billingErr
-	}
-	if !billingResult.Success {
-		return &SpeechResult{Success: false, Error: fmt.Errorf(billingResult.ErrorMessage)}, nil
+	// 1. Calculate cost and CHECK balance if billing is enabled
+	hasSufficientBalance := true
+	var requiredDCR, currentBalanceDCR float64
+	var checkErr error
+	var insufErrMsg string
+	if s.billingEnabled {
+		hasSufficientBalance, requiredDCR, currentBalanceDCR, insufErrMsg, checkErr = utils.CheckBalance(ctx, s.dbManager, req.UserID[:], req.PriceUSD, s.debug, s.billingEnabled)
+		if checkErr != nil {
+			// Critical error during balance check
+			err := fmt.Errorf("failed during balance check: %v", checkErr)
+			return &SpeechResult{Success: false, Error: err}, err
+		}
+		if !hasSufficientBalance {
+			// Insufficient funds
+			return &SpeechResult{Success: false, Error: fmt.Errorf(insufErrMsg)}, nil
+		}
 	}
 
-	// 2. Send initial message
-	s.bot.SendPM(ctx, req.UserNick, "Processing your speech request.")
+	// 2. Send initial message (adjusted for billing status)
+	var infoMsg string
+	if s.billingEnabled {
+		infoMsg = fmt.Sprintf("Request cost: $%.2f USD (%.8f DCR). Your balance: %.8f DCR. Processing speech request...", req.PriceUSD, requiredDCR, currentBalanceDCR)
+	} else {
+		infoMsg = "Processing your speech request (billing disabled)..."
+	}
+	s.bot.SendPM(ctx, req.UserNick, infoMsg)
 
 	// 3. Create the appropriate FAL request object using the helper function
 	falReq, err := createFalSpeechRequest(req)
 	if err != nil {
-		// Optional: Refund logic
-		return &SpeechResult{Success: false, Error: err}, err
+		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Error creating speech request: %v", err))
+		return &SpeechResult{Success: false, Error: err}, err // No billing occurred
 	}
 
 	// 4. Generate speech using the created request
-	audioResp, err := s.client.GenerateSpeech(ctx, falReq)
-	if err != nil {
-		// Optional: Refund logic
-		return &SpeechResult{Success: false, Error: err}, err
+	audioResp, genErr := s.client.GenerateSpeech(ctx, falReq)
+	if genErr != nil {
+		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Speech generation failed: %v", genErr))
+		return &SpeechResult{Success: false, Error: genErr}, genErr // No billing occurred
 	}
 
 	// 5. Check if the audio URL is empty
 	if audioResp.AudioURL == "" {
-		err = fmt.Errorf("received empty audio URL from API")
-		// Optional: Refund logic
-		return &SpeechResult{Success: false, Error: err}, err
+		genErr = fmt.Errorf("received empty audio URL from API")
+		s.bot.SendPM(ctx, req.UserNick, genErr.Error())
+		return &SpeechResult{Success: false, Error: genErr}, genErr // No billing occurred
 	}
 
 	// 6. Download and send audio
+	successfullySent := false
 	if err := s.downloadAndSendAudio(ctx, req.UserNick, audioResp.AudioURL, req.ModelName); err != nil {
-		// Optional: Refund logic, although user was likely charged already
-		return &SpeechResult{Success: false, Error: err}, err
+		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to send audio file: %v", err))
+		// Continue, but don't bill
+	} else {
+		successfullySent = true
 	}
 
-	// 7. Send billing info
-	if err := utils.SendBillingMessage(ctx, s.bot, pm, billingResult); err != nil {
-		// Log error, but don't fail the whole operation
-		fmt.Printf("ERROR: Failed to send billing message to %s: %v\n", req.UserNick, err)
+	// 7. Perform Billing *only if* enabled and audio was sent successfully
+	var chargedDCR float64
+	var finalBalanceDCR float64 = currentBalanceDCR // Use balance from initial check
+	var billingAttempted bool = false
+	var billingSucceeded bool = false
+
+	if s.billingEnabled && successfullySent {
+		billingAttempted = true
+		deductChargedDCR, deductNewBalance, deductErr := utils.DeductBalance(ctx, s.dbManager, req.UserID[:], req.PriceUSD, s.debug, s.billingEnabled)
+		if deductErr != nil {
+			s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Error processing payment after sending audio: %v. Please contact support.", deductErr))
+			finalBalanceDCR = currentBalanceDCR // Use pre-deduction balance
+		} else {
+			billingSucceeded = true
+			chargedDCR = deductChargedDCR
+			finalBalanceDCR = deductNewBalance
+		}
+	} else if !s.billingEnabled {
+		// fmt.Printf("INFO: Billing disabled. No charge for speech for user %s.\n", req.UserNick) // Already Removed
+	} else {
+		// Billing enabled, but not sent successfully
+		// fmt.Printf("INFO: Audio not sent successfully for user %s. No billing occurred.\n", req.UserNick) // Removed
 	}
 
+	// 8. Send final confirmation
+	finalMessage := "Finished processing speech request.\n\n"
+	if !successfullySent {
+		finalMessage = "Speech generation completed, but failed to send the result.\n\n"
+	}
+
+	if s.billingEnabled {
+		if billingAttempted && billingSucceeded {
+			finalMessage += fmt.Sprintf("💰 Billing Information:\n• Charged: %.8f DCR ($%.2f USD)\n• New Balance: %.8f DCR",
+				chargedDCR, req.PriceUSD, finalBalanceDCR)
+		} else if billingAttempted && !billingSucceeded {
+			finalMessage += fmt.Sprintf("⚠️ Billing failed after sending audio. Your balance remains %.8f DCR. Please contact support.", finalBalanceDCR)
+		} else {
+			finalMessage += fmt.Sprintf("No charge was applied. Your balance remains %.8f DCR.", finalBalanceDCR)
+		}
+	} else {
+		finalMessage += "Billing is disabled. No charge was applied."
+	}
+
+	if err := s.bot.SendPM(ctx, req.UserNick, finalMessage); err != nil {
+		// fmt.Printf("ERROR: Failed to send final confirmation message (speech) to %s: %v\n", req.UserNick, err) // Removed
+	}
+
+	// Return overall success based on generation, even if sending/billing failed
 	return &SpeechResult{
 		AudioURL: audioResp.AudioURL,
-		Success:  true,
+		Success:  true, // Represents successful generation
 	}, nil
 }
 

--- a/internal/utils/billing.go
+++ b/internal/utils/billing.go
@@ -91,3 +91,119 @@ func SendBillingMessage(ctx context.Context, bot *kit.Bot, pm types.ReceivedPM, 
 	billingMsg := FormatBillingMessage(result.ChargedDCR, result.ChargedUSD, result.NewBalance)
 	return bot.SendPM(ctx, pm.Nick, billingMsg)
 }
+
+// CheckBalance checks if a user has sufficient balance for a given cost in USD, without deducting.
+// It returns whether the balance is sufficient, the required DCR amount, the current balance in DCR,
+// an error message if insufficient, and any critical error encountered.
+// If billingEnabled is false, it always returns success.
+func CheckBalance(ctx context.Context, dbManager *database.DBManager, userID []byte, costUSD float64, debug bool, billingEnabled bool) (hasSufficientBalance bool, requiredDCR float64, currentBalanceDCR float64, errMsg string, err error) {
+	// Get current balance regardless of billing status for reporting
+	userIDStr := GetUserIDString(userID)
+	balanceAtoms, balanceErr := dbManager.GetBalance(userIDStr)
+	if balanceErr != nil {
+		// Return this error even if billing is disabled, as it prevents knowing the balance
+		err = fmt.Errorf("failed to get balance: %v", balanceErr)
+		return
+	}
+	currentBalanceDCR = float64(balanceAtoms) / 1e11
+
+	// If billing is disabled, always return true (balance sufficient)
+	if !billingEnabled {
+		hasSufficientBalance = true
+		requiredDCR = 0 // No cost applied
+		errMsg = "Billing is disabled."
+		return
+	}
+
+	// --- Billing is enabled, perform normal checks ---
+
+	// Convert USD cost to DCR
+	requiredDCR, err = USDToDCR(costUSD)
+	if err != nil {
+		err = fmt.Errorf("failed to convert USD to DCR: %v", err)
+		return
+	}
+
+	// Convert DCR amount to atoms for comparison (1 DCR = 1e11 atoms)
+	dcrAtoms := int64(requiredDCR * 1e11)
+
+	// Debug information
+	if debug {
+		fmt.Print(FormatDebugBalanceInfo(userIDStr, balanceAtoms, costUSD, requiredDCR, dcrAtoms))
+	}
+
+	// Check if user has sufficient balance
+	if balanceAtoms < dcrAtoms {
+		hasSufficientBalance = false
+		errMsg = FormatInsufficientBalanceMessageWithUSD(requiredDCR, currentBalanceDCR, costUSD)
+		return // Not a critical error, just insufficient funds
+	}
+
+	hasSufficientBalance = true
+	return // Sufficient balance
+}
+
+// DeductBalance deducts the specified cost in USD from the user's balance.
+// It assumes the balance check has already passed IF billing is enabled.
+// Returns the amount charged in DCR, the new balance in DCR, and any error encountered.
+// If billingEnabled is false, it returns zero charged and the current balance without hitting the DB.
+func DeductBalance(ctx context.Context, dbManager *database.DBManager, userID []byte, costUSD float64, debug bool, billingEnabled bool) (chargedDCR float64, newBalanceDCR float64, err error) {
+	// Get current balance first
+	currentBalanceDCR, balanceErr := dbManager.GetUserBalance(userID) // Assuming GetUserBalance returns DCR
+	if balanceErr != nil {
+		err = fmt.Errorf("failed to get current balance before deduction attempt: %v", balanceErr)
+		return
+	}
+
+	// If billing is disabled, do nothing and return current balance
+	if !billingEnabled {
+		chargedDCR = 0
+		newBalanceDCR = currentBalanceDCR
+		return // Success (no-op)
+	}
+
+	// --- Billing is enabled, perform deduction ---
+
+	// Deduct balance using CheckAndDeductBalance
+	// Note: CheckAndDeductBalance itself likely converts USD internally based on its signature
+	hasBalanceAfterDeduct, err := dbManager.CheckAndDeductBalance(userID, costUSD, debug)
+	if err != nil {
+		err = fmt.Errorf("failed to deduct balance: %v", err)
+		newBalanceDCR = currentBalanceDCR // Return pre-deduction balance on error
+		return
+	}
+	// This check might be redundant if CheckBalance was called first,
+	// but CheckAndDeductBalance performs an atomic check-and-deduct.
+	if !hasBalanceAfterDeduct {
+		// This indicates a potential race condition or logic error if CheckBalance passed moments before.
+		err = fmt.Errorf("deduction failed despite prior check (insufficient funds or race condition)")
+		newBalanceDCR = currentBalanceDCR // Return pre-deduction balance on error
+		return
+	}
+
+	// Convert charged amount back to DCR for reporting (if needed, depends on CheckAndDeductBalance return)
+	// Assuming costUSD was the amount successfully deducted in USD terms.
+	chargedDCR, convertErr := USDToDCR(costUSD)
+	if convertErr != nil {
+		// Log this error, but the deduction likely succeeded, so proceed with getting new balance.
+		fmt.Printf("WARN: Failed to convert charged USD to DCR for reporting: %v\n", convertErr)
+		chargedDCR = 0 // Assign a placeholder
+	}
+
+	// Get updated balance for result
+	finalBalanceDCR, finalBalanceErr := dbManager.GetUserBalance(userID) // Assuming GetUserBalance returns DCR
+	if finalBalanceErr != nil {
+		// The deduction likely succeeded, but we failed to get the final balance.
+		err = fmt.Errorf("deduction likely succeeded, but failed to get updated balance: %v", finalBalanceErr)
+		newBalanceDCR = currentBalanceDCR // Return pre-deduction balance as best guess
+		return
+	}
+	newBalanceDCR = finalBalanceDCR
+
+	// Debug information after deduction
+	if debug {
+		fmt.Print(FormatDebugAfterDeduction(int64(newBalanceDCR * 1e11)))
+	}
+
+	return // Success
+}

--- a/internal/video/service.go
+++ b/internal/video/service.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/companyzero/bisonrelay/clientrpc/types"
+	// "github.com/companyzero/bisonrelay/clientrpc/types" // Only needed for the old billing call
 	"github.com/karamble/braibot/internal/database"
 	"github.com/karamble/braibot/internal/faladapter"
 	"github.com/karamble/braibot/internal/utils"
@@ -17,85 +17,147 @@ import (
 
 // VideoService handles video generation
 type VideoService struct {
-	client    *fal.Client
-	dbManager *database.DBManager
-	bot       *kit.Bot
-	debug     bool
+	client         *fal.Client
+	dbManager      *database.DBManager
+	bot            *kit.Bot
+	debug          bool
+	billingEnabled bool // Added billing enabled flag
 }
 
 // NewVideoService creates a new VideoService
-func NewVideoService(client *fal.Client, dbManager *database.DBManager, bot *kit.Bot, debug bool) *VideoService {
+func NewVideoService(client *fal.Client, dbManager *database.DBManager, bot *kit.Bot, debug bool, billingEnabled bool) *VideoService {
 	return &VideoService{
-		client:    client,
-		dbManager: dbManager,
-		bot:       bot,
-		debug:     debug,
+		client:         client,
+		dbManager:      dbManager,
+		bot:            bot,
+		debug:          debug,
+		billingEnabled: billingEnabled, // Store the flag
 	}
 }
 
-// GenerateVideo generates a video based on the request
+// GenerateVideo generates a video based on the request, handling billing conditionally.
 func (s *VideoService) GenerateVideo(ctx context.Context, req *VideoRequest) (*VideoResult, error) {
 	// 1. Validate request
 	if err := s.validateRequest(req); err != nil {
 		return &VideoResult{Success: false, Error: err}, err
 	}
 
-	// 2. Check if user has sufficient balance
-	pm := types.ReceivedPM{
-		Nick: req.UserNick,
-		Uid:  req.UserID[:], // Convert zkidentity.ShortID to []byte
-	}
-	billingResult, err := utils.CheckAndProcessBilling(ctx, s.bot, s.dbManager, pm, req.PriceUSD, s.debug)
-	if err != nil {
-		return &VideoResult{Success: false, Error: err}, err
-	}
-	if !billingResult.Success {
-		return &VideoResult{Success: false, Error: fmt.Errorf(billingResult.ErrorMessage)}, nil
+	// 2. Calculate cost and CHECK balance if billing is enabled
+	hasSufficientBalance := true
+	var requiredDCR, currentBalanceDCR float64
+	var checkErr error
+	var insufErrMsg string
+	if s.billingEnabled {
+		hasSufficientBalance, requiredDCR, currentBalanceDCR, insufErrMsg, checkErr = utils.CheckBalance(ctx, s.dbManager, req.UserID[:], req.PriceUSD, s.debug, s.billingEnabled)
+		if checkErr != nil {
+			// Critical error during balance check
+			err := fmt.Errorf("failed during balance check: %v", checkErr)
+			return &VideoResult{Success: false, Error: err}, err
+		}
+		if !hasSufficientBalance {
+			// Insufficient funds
+			return &VideoResult{Success: false, Error: fmt.Errorf(insufErrMsg)}, nil
+		}
 	}
 
-	// 3. Send initial message
-	s.bot.SendPM(ctx, req.UserNick, "Processing your request.")
+	// 3. Send initial message (adjusted for billing status)
+	var infoMsg string
+	if s.billingEnabled {
+		infoMsg = fmt.Sprintf("Request cost: $%.2f USD (%.8f DCR). Your balance: %.8f DCR. Processing...", req.PriceUSD, requiredDCR, currentBalanceDCR)
+	} else {
+		infoMsg = "Processing your request (billing disabled)..."
+	}
+	s.bot.SendPM(ctx, req.UserNick, infoMsg)
 
 	// 4. Get current model name
 	model, exists := faladapter.GetCurrentModel(req.ModelType)
 	if !exists {
-		return &VideoResult{Success: false, Error: fmt.Errorf("no default model found for %s", req.ModelType)}, nil
+		return &VideoResult{Success: false, Error: fmt.Errorf("no default model found for %s", req.ModelType)}, nil // No billing occurred
 	}
 
 	// 5. Create the appropriate FAL request object using the helper function
 	falReq, err := createFalVideoRequest(req, model.Name)
 	if err != nil {
 		// Handle error from request creation (e.g., unsupported model)
-		// Optional: Add refund logic here if needed
-		return &VideoResult{Success: false, Error: err}, err
+		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Error creating generation request: %v", err))
+		return &VideoResult{Success: false, Error: err}, err // No billing occurred
 	}
 
 	// 6. Generate video using the created request
-	videoResp, err := s.client.GenerateVideo(ctx, falReq)
-	if err != nil {
-		// Optional: Add refund logic here if needed
-		return &VideoResult{Success: false, Error: err}, err
+	videoResp, genErr := s.client.GenerateVideo(ctx, falReq)
+	if genErr != nil {
+		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Video generation failed: %v", genErr))
+		return &VideoResult{Success: false, Error: genErr}, genErr // No billing occurred
 	}
 
-	// 7. Download and send video
+	// 7. Check if URL is present and attempt to send
 	videoURL := videoResp.GetURL()
 	if videoURL == "" {
-		err = fmt.Errorf("no video URL found in response")
-		return &VideoResult{Success: false, Error: err}, err
+		genErr = fmt.Errorf("API did not return a video URL")
+		s.bot.SendPM(ctx, req.UserNick, genErr.Error())
+		return &VideoResult{Success: false, Error: genErr}, genErr // No billing occurred
 	}
 
+	successfullySent := false
 	if err := s.downloadAndSendVideo(ctx, req.UserNick, videoURL); err != nil {
-		return &VideoResult{Success: false, Error: err}, err
+		s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Failed to send video: %v", err))
+		// Continue to billing potentially? Or return error? For now, continue but don't bill.
+	} else {
+		successfullySent = true
 	}
 
-	// 8. Send billing info
-	if err := utils.SendBillingMessage(ctx, s.bot, pm, billingResult); err != nil {
-		return &VideoResult{Success: false, Error: err}, err
+	// 8. Perform Billing *only if* enabled and video was sent successfully
+	var chargedDCR float64
+	var finalBalanceDCR float64 = currentBalanceDCR // Use balance from initial check
+	var billingAttempted bool = false
+	var billingSucceeded bool = false
+
+	if s.billingEnabled && successfullySent {
+		billingAttempted = true
+		deductChargedDCR, deductNewBalance, deductErr := utils.DeductBalance(ctx, s.dbManager, req.UserID[:], req.PriceUSD, s.debug, s.billingEnabled)
+		if deductErr != nil {
+			s.bot.SendPM(ctx, req.UserNick, fmt.Sprintf("Error processing payment after sending video: %v. Please contact support.", deductErr))
+			// Use pre-deduction balance
+			finalBalanceDCR = currentBalanceDCR
+		} else {
+			billingSucceeded = true
+			chargedDCR = deductChargedDCR
+			finalBalanceDCR = deductNewBalance
+		}
+	} else if !s.billingEnabled {
+		// fmt.Printf("INFO: Billing disabled. No charge for video for user %s.\n", req.UserNick) // Already Removed
+	} else {
+		// Billing enabled, but not sent successfully
+		// fmt.Printf("INFO: Video not sent successfully for user %s. No billing occurred.\n", req.UserNick) // Removed
 	}
 
+	// 9. Send final confirmation
+	finalMessage := "Finished processing video request.\n\n"
+	if !successfullySent {
+		finalMessage = "Video generation completed, but failed to send the result.\n\n"
+	}
+
+	if s.billingEnabled {
+		if billingAttempted && billingSucceeded {
+			finalMessage += fmt.Sprintf("💰 Billing Information:\n• Charged: %.8f DCR ($%.2f USD)\n• New Balance: %.8f DCR",
+				chargedDCR, req.PriceUSD, finalBalanceDCR)
+		} else if billingAttempted && !billingSucceeded {
+			finalMessage += fmt.Sprintf("⚠️ Billing failed after sending video. Your balance remains %.8f DCR. Please contact support.", finalBalanceDCR)
+		} else {
+			finalMessage += fmt.Sprintf("No charge was applied. Your balance remains %.8f DCR.", finalBalanceDCR)
+		}
+	} else {
+		finalMessage += "Billing is disabled. No charge was applied."
+	}
+
+	if err := s.bot.SendPM(ctx, req.UserNick, finalMessage); err != nil {
+		// fmt.Printf("ERROR: Failed to send final confirmation message (video) to %s: %v\n", req.UserNick, err) // Removed
+	}
+
+	// Return overall success based on generation, even if sending/billing failed
 	return &VideoResult{
 		VideoURL: videoURL,
-		Success:  true,
+		Success:  true, // Represents successful generation
 	}, nil
 }
 

--- a/pkg/fal/image.go
+++ b/pkg/fal/image.go
@@ -335,7 +335,7 @@ func (c *Client) GenerateImage(ctx context.Context, req interface{}) (*ImageResp
 				URL         string `json:"url"`
 				ContentType string `json:"content_type"`
 			} `json:"svg"`
-			Seed int `json:"seed"` // Capture top-level seed here too
+			Seed uint64 `json:"seed"` // Changed from int to uint64
 		}
 
 		if err := json.Unmarshal(data, &singleImageResp); err != nil {
@@ -360,12 +360,8 @@ func (c *Client) GenerateImage(ctx context.Context, req interface{}) (*ImageResp
 			return nil, fmt.Errorf("final response did not contain a valid image or svg URL. Body: %s", string(data))
 		}
 
-		response.Images = []struct {
-			URL         string `json:"url"`
-			ContentType string `json:"content_type"`
-			Width       int    `json:"width"`
-			Height      int    `json:"height"`
-		}{
+		// Use the named struct ImageOutput when assigning the slice
+		response.Images = []ImageOutput{
 			{
 				URL:         imgURL,
 				ContentType: imgContentType,

--- a/pkg/fal/types.go
+++ b/pkg/fal/types.go
@@ -344,18 +344,21 @@ type FluxProV1_1Request struct {
 	OutputFormat        string `json:"output_format,omitempty"`
 }
 
+// ImageOutput represents a single image result within an ImageResponse
+type ImageOutput struct {
+	URL         string `json:"url"`
+	ContentType string `json:"content_type"`
+	Width       int    `json:"width"`
+	Height      int    `json:"height"`
+}
+
 // ImageResponse represents the response from an image generation request
 type ImageResponse struct {
-	Images []struct {
-		URL         string `json:"url"`
-		ContentType string `json:"content_type"`
-		Width       int    `json:"width"`
-		Height      int    `json:"height"`
-	} `json:"images"`
-	NSFW        bool      `json:"nsfw"`
-	CreatedAt   time.Time `json:"created_at"`
-	CompletedAt time.Time `json:"completed_at"`
-	Seed        int       `json:"seed"` // Seed used for the generation
+	Images      []ImageOutput `json:"images"`
+	NSFW        bool          `json:"nsfw"`
+	CreatedAt   time.Time     `json:"created_at"`
+	CompletedAt time.Time     `json:"completed_at"`
+	Seed        uint64        `json:"seed"`
 }
 
 // BaseSpeechRequest represents the base fields for a speech generation request


### PR DESCRIPTION
closes #27 

## Refactor Billing Logic and Add Configuration Flag

This PR refactors the billing mechanism for AI generation commands (image, video, speech) and introduces a configuration flag to enable/disable billing entirely.

**Key Changes:**

1.  **Delayed Billing:**
    *   Billing for AI tasks now occurs *after* the generated result (image, video, audio file) has been successfully sent to the user, rather than upfront.
    *   This involved separating the balance check (`utils.CheckBalance`) from the deduction (`utils.DeductBalance`) and updating the service logic (`image.GenerateImage`, `video.GenerateVideo`, `speech.GenerateSpeech`) to follow the **Check -> Generate -> Send -> Deduct** flow.

2.  **`billingenabled` Configuration:**
    *   Added a new `billingenabled` setting to `braibot.conf`.
    *   If the setting is missing on startup, the user is interactively prompted via the console to enable billing (yes/no), and their choice is saved to the config file.
    *   If the setting exists but is invalid (not "true" or "false"), it defaults to "true".
    *   All billing-related functions (`CheckBalance`, `DeductBalance`), service methods, and the `!balance` command now respect this flag. User messages are adjusted accordingly (e.g., not mentioning costs if billing is disabled).

**Related Fixes:**

*   **Service Initialization:** Corrected the `image2image` command handler (`internal/commands/image2image.go`) to use the centrally initialized `ImageService` instance instead of creating its own.
