### PR TITLE
add support for four new video generation models from minimax

### DIFF
--- a/internal/commands/text2video.go
+++ b/internal/commands/text2video.go
@@ -63,7 +63,7 @@ func Text2VideoCommand(dbManager *database.DBManager, videoService *video.VideoS
 			// Parse arguments using the video parser
 			parser := video.NewArgumentParser()
 			// Update variable list to match parser.Parse return values
-			prompt, _, duration, aspectRatio, negativePrompt, cfgScalePtr, err := parser.Parse(args, false) // Expect NO Image URL
+			prompt, _, duration, aspectRatio, negativePrompt, cfgScalePtr, promptOptimizerPtr, err := parser.Parse(args, false) // Expect NO Image URL
 			if err != nil {
 				return bot.SendPM(ctx, pm.Nick, fmt.Sprintf("Argument error: %v", err))
 			}
@@ -84,16 +84,17 @@ func Text2VideoCommand(dbManager *database.DBManager, videoService *video.VideoS
 			var userID zkidentity.ShortID
 			userID.FromBytes(pm.Uid)
 			req := &video.VideoRequest{
-				Prompt:         prompt,
-				Duration:       duration,
-				AspectRatio:    aspectRatio,
-				NegativePrompt: negativePrompt,
-				CFGScale:       cfgScalePtr, // Assign the parsed pointer
-				ModelType:      "text2video",
-				Progress:       progress,
-				UserNick:       pm.Nick,
-				UserID:         userID,
-				PriceUSD:       model.PriceUSD,
+				Prompt:          prompt,
+				Duration:        duration,
+				AspectRatio:     aspectRatio,
+				NegativePrompt:  negativePrompt,
+				CFGScale:        cfgScalePtr,        // Assign the parsed pointer
+				PromptOptimizer: promptOptimizerPtr, // Assign the parsed pointer
+				ModelType:       "text2video",
+				Progress:        progress,
+				UserNick:        pm.Nick,
+				UserID:          userID,
+				PriceUSD:        model.PriceUSD,
 			}
 
 			// Generate video

--- a/internal/video/types.go
+++ b/internal/video/types.go
@@ -7,17 +7,19 @@ import (
 
 // VideoRequest represents a request to generate a video
 type VideoRequest struct {
-	Prompt         string
-	ImageURL       string   // Optional for text2video
-	Duration       string   // Optional, defaults handled by FAL
-	AspectRatio    string   // Optional, defaults handled by FAL
-	NegativePrompt string   // Optional, defaults handled by FAL
-	CFGScale       *float64 // Optional, use pointer to track if set
-	ModelType      string   // "text2video" or "image2video"
-	Progress       fal.ProgressCallback
-	UserNick       string
-	UserID         zkidentity.ShortID
-	PriceUSD       float64
+	Prompt                   string
+	ImageURL                 string   // Optional, used by some image2video models (Veo2, Kling)
+	SubjectReferenceImageURL string   // Optional, used by minimax-subject-reference
+	Duration                 string   // Optional, defaults handled by FAL
+	AspectRatio              string   // Optional, defaults handled by FAL
+	NegativePrompt           string   // Optional, defaults handled by FAL
+	CFGScale                 *float64 // Optional, use pointer to track if set
+	PromptOptimizer          *bool    // Optional, for minimax-director model
+	ModelType                string   // "text2video" or "image2video"
+	Progress                 fal.ProgressCallback
+	UserNick                 string
+	UserID                   zkidentity.ShortID
+	PriceUSD                 float64
 }
 
 // VideoResult represents the result of a video generation

--- a/pkg/fal/image_video_models.go
+++ b/pkg/fal/image_video_models.go
@@ -42,7 +42,45 @@ func (m *klingVideoImageModel) Define() Model {
 	}
 }
 
+// --- minimax/video-01-subject-reference ---
+
+type minimaxSubjectReferenceModel struct{}
+
+func (m *minimaxSubjectReferenceModel) Define() Model {
+	defaultOptimizer := true
+	return Model{
+		Name:        "minimax/video-01-subject-reference",
+		Description: "Generate video from a subject reference image.",
+		PriceUSD:    0.8,
+		Type:        "image2video",
+		HelpDoc:     "Usage: !image2video [subject_reference_image_url] [prompt] [options]\nExample: !image2video https://example.com/subject.jpg a person walking --prompt-optimizer false\n\nParameters:\n• subject_reference_image_url: URL of the image to use for consistent subject appearance.\n• prompt: Description of the desired video animation.\n• --prompt-optimizer: Whether to use the model's prompt optimizer (default: true)",
+		Options: &MinimaxSubjectReferenceOptions{
+			PromptOptimizer: &defaultOptimizer,
+		},
+	}
+}
+
+// --- minimax/video-01-live ---
+
+type minimaxLiveModel struct{}
+
+func (m *minimaxLiveModel) Define() Model {
+	defaultOptimizer := true
+	return Model{
+		Name:        "minimax/video-01-live",
+		Description: "Generate video from an image, specialized in bringing 2D illustrations to life.",
+		PriceUSD:    0.8,
+		Type:        "image2video",
+		HelpDoc:     "Usage: !image2video [image_url] [prompt] [options]\nExample: !image2video https://example.com/image.png A character waving --prompt-optimizer true\n\nInfo: This model is specialized in bringing 2D illustrations to life.\n\nParameters:\n• image_url: URL of the image to animate.\n• prompt: Description of the desired video animation.\n• --prompt-optimizer: Whether to use the model's prompt optimizer (default: true)",
+		Options: &MinimaxLiveOptions{
+			PromptOptimizer: &defaultOptimizer,
+		},
+	}
+}
+
 func init() {
 	registerModel(&veo2Model{})
 	registerModel(&klingVideoImageModel{})
+	registerModel(&minimaxSubjectReferenceModel{})
+	registerModel(&minimaxLiveModel{})
 }

--- a/pkg/fal/text_video_models.go
+++ b/pkg/fal/text_video_models.go
@@ -27,3 +27,47 @@ func (m *klingVideoTextModel) Define() Model {
 func init() {
 	registerModel(&klingVideoTextModel{})
 }
+
+// --- minimax-video-01-director ---
+
+type minimaxDirectorModel struct{}
+
+func (m *minimaxDirectorModel) Define() Model {
+	defaultOptimizer := true
+	return Model{
+		Name:        "minimax/video-01-director",
+		Description: "Generate video clips with camera movement instructions.",
+		PriceUSD:    0.8, // TODO: Update with actual price
+		Type:        "text2video",
+		HelpDoc:     "Usage: !text2video [prompt] [options]\n\nParameters:\n• prompt: Description of the desired video. Include camera movements in square brackets `[]`.\n  - Single movement: `[Push in] A cat walking.`\n  - Combined (up to 3): `[Truck left, Pan right, Zoom in] A busy street scene.`\n  - Available movements: `Truck left/right`, `Pan left/right`, `Push in/Pull out`, `Pedestal up/down`, `Tilt up/down`, `Zoom in/out`, `Shake`, `Tracking shot`, `Static shot`. \n  - More details: https://sixth-switch-2ac.notion.site/T2V-01-Director-Model-Tutorial-with-camera-movement-1886c20a98eb80f395b8e05291ad8645\n• --prompt-optimizer: Whether to use the model's prompt optimizer (default: true)",
+		Options: &MinimaxDirectorOptions{
+			PromptOptimizer: &defaultOptimizer,
+		},
+	}
+}
+
+func init() {
+	registerModel(&minimaxDirectorModel{})
+}
+
+// --- minimax/video-01 ---
+
+type minimaxVideo01Model struct{}
+
+func (m *minimaxVideo01Model) Define() Model {
+	defaultOptimizer := true
+	return Model{
+		Name:        "minimax/video-01",
+		Description: "Native high-resolution, high-frame-rate video generation model.",
+		PriceUSD:    0.8,
+		Type:        "text2video",
+		HelpDoc:     "Usage: !text2video [prompt] [options]\nExample: !text2video A futuristic cityscape --prompt-optimizer true\n\nParameters:\n• prompt: Description of the desired video.\n• --prompt-optimizer: Whether to use the model's prompt optimizer (default: true)",
+		Options: &MinimaxVideo01Options{
+			PromptOptimizer: &defaultOptimizer,
+		},
+	}
+}
+
+func init() {
+	registerModel(&minimaxVideo01Model{})
+}

--- a/pkg/fal/types.go
+++ b/pkg/fal/types.go
@@ -102,14 +102,35 @@ func (o *KlingVideoOptions) Validate() error {
 	return nil
 }
 
+// MinimaxDirectorOptions represents the options available for the minimax-video-01-director model
+type MinimaxDirectorOptions struct {
+	PromptOptimizer *bool `json:"prompt_optimizer,omitempty"` // Default: true
+}
+
+// GetDefaultValues returns the default values for MinimaxDirector options
+func (o *MinimaxDirectorOptions) GetDefaultValues() map[string]interface{} {
+	defaultOptimizer := true
+	return map[string]interface{}{
+		"prompt_optimizer": &defaultOptimizer,
+	}
+}
+
+// Validate validates the MinimaxDirector options
+func (o *MinimaxDirectorOptions) Validate() error {
+	// No specific validation needed for a boolean flag yet
+	return nil
+}
+
 // FluxSchnellOptions represents the options available for the fal-ai/flux/schnell model
 type FluxSchnellOptions struct {
-	ImageSize           string `json:"image_size,omitempty"`            // square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9
-	NumInferenceSteps   int    `json:"num_inference_steps,omitempty"`   // Default: 4
-	Seed                *int   `json:"seed,omitempty"`                  // Optional seed
-	SyncMode            bool   `json:"sync_mode,omitempty"`             // Default: false
-	NumImages           int    `json:"num_images,omitempty"`            // Default: 1
-	EnableSafetyChecker *bool  `json:"enable_safety_checker,omitempty"` // Default: true
+	ImageSize           string  `json:"image_size,omitempty"`            // square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9
+	NumInferenceSteps   int     `json:"num_inference_steps,omitempty"`   // Default: 4
+	Seed                *int    `json:"seed,omitempty"`                  // Optional seed
+	SyncMode            bool    `json:"sync_mode,omitempty"`             // Default: false
+	NumImages           int     `json:"num_images,omitempty"`            // Default: 1
+	EnableSafetyChecker *bool   `json:"enable_safety_checker,omitempty"` // Default: true
+	CFGScale            float64 `json:"cfg_scale,omitempty"`
+	PromptOptimizer     *bool   `json:"prompt_optimizer,omitempty"` // Mirrored option
 }
 
 // GetDefaultValues returns the default values for Flux Schnell options
@@ -657,4 +678,86 @@ type CartoonifyRequest struct {
 // StarVectorRequest represents a request for the star-vector model
 type StarVectorRequest struct {
 	BaseImageRequest // Requires ImageURL
+}
+
+// MinimaxDirectorRequest represents a request to generate a video using the minimax-video-01-director model
+type MinimaxDirectorRequest struct {
+	BaseVideoRequest
+	PromptOptimizer *bool `json:"prompt_optimizer,omitempty"`
+}
+
+// MinimaxSubjectReferenceOptions represents options for minimax/video-01-subject-reference
+type MinimaxSubjectReferenceOptions struct {
+	PromptOptimizer *bool `json:"prompt_optimizer,omitempty"` // Default: true
+}
+
+// GetDefaultValues returns default values for MinimaxSubjectReferenceOptions
+func (o *MinimaxSubjectReferenceOptions) GetDefaultValues() map[string]interface{} {
+	defaultOptimizer := true
+	return map[string]interface{}{
+		"prompt_optimizer": &defaultOptimizer,
+	}
+}
+
+// Validate validates MinimaxSubjectReferenceOptions
+func (o *MinimaxSubjectReferenceOptions) Validate() error {
+	// No validation needed for a boolean flag yet
+	return nil
+}
+
+// MinimaxSubjectReferenceRequest represents a request for minimax/video-01-subject-reference
+type MinimaxSubjectReferenceRequest struct {
+	BaseVideoRequest                // Embeds Prompt, Progress, Model, Options
+	SubjectReferenceImageURL string `json:"subject_reference_image_url"` // Specific required field
+	PromptOptimizer          *bool  `json:"prompt_optimizer,omitempty"`  // Mirrored option
+}
+
+// MinimaxLiveOptions represents options for minimax/video-01-live
+type MinimaxLiveOptions struct {
+	PromptOptimizer *bool `json:"prompt_optimizer,omitempty"` // Default: true
+}
+
+// GetDefaultValues returns default values for MinimaxLiveOptions
+func (o *MinimaxLiveOptions) GetDefaultValues() map[string]interface{} {
+	defaultOptimizer := true
+	return map[string]interface{}{
+		"prompt_optimizer": &defaultOptimizer,
+	}
+}
+
+// Validate validates MinimaxLiveOptions
+func (o *MinimaxLiveOptions) Validate() error {
+	// No validation needed for a boolean flag yet
+	return nil
+}
+
+// MinimaxLiveRequest represents a request for minimax/video-01-live
+type MinimaxLiveRequest struct {
+	BaseVideoRequest       // Embeds Prompt, ImageURL, Progress, Model, Options
+	PromptOptimizer  *bool `json:"prompt_optimizer,omitempty"` // Mirrored option
+}
+
+// MinimaxVideo01Options represents options for minimax/video-01
+type MinimaxVideo01Options struct {
+	PromptOptimizer *bool `json:"prompt_optimizer,omitempty"` // Default: true
+}
+
+// GetDefaultValues returns default values for MinimaxVideo01Options
+func (o *MinimaxVideo01Options) GetDefaultValues() map[string]interface{} {
+	defaultOptimizer := true
+	return map[string]interface{}{
+		"prompt_optimizer": &defaultOptimizer,
+	}
+}
+
+// Validate validates MinimaxVideo01Options
+func (o *MinimaxVideo01Options) Validate() error {
+	// No validation needed for a boolean flag yet
+	return nil
+}
+
+// MinimaxVideo01Request represents a request for minimax/video-01
+type MinimaxVideo01Request struct {
+	BaseVideoRequest       // Embeds Prompt, Progress, Model, Options (ImageURL should be empty)
+	PromptOptimizer  *bool `json:"prompt_optimizer,omitempty"` // Mirrored option
 }


### PR DESCRIPTION
-   **minimax/video-01** (text2video): Native high-resolution, high-frame-rate text-to-video generation.
-   **minimax/video-01-director** (text2video): Text-to-video generation with camera movement controls (e.g., `[Push in]`).
-   **minimax/video-01-live** (image2video): Animates images, specialized for 2D illustrations.
-   **minimax/video-01-subject-reference** (image2video): Generates video using a subject reference image for consistency.

Implementation details:

-   Added necessary options and request structs to `pkg/fal/types.go`.
-   Defined and registered models in `pkg/fal/text_video_models.go` and `pkg/fal/image_video_models.go`, including help documentation.
-   Updated `internal/video/types.go` to include `SubjectReferenceImageURL` and `PromptOptimizer`.
-   Updated argument parser (`internal/video/parser.go`) to handle `--prompt-optimizer`.
-   Modified command handlers (`text2video.go`, `image2video.go`) to correctly parse arguments and populate internal video requests based on the selected model.
-   Updated `internal/video/service.go` (`createFalVideoRequest`) to map internal requests to the specific FAL request types and added model-specific validation logic (`validateRequest`).
-   Updated `pkg/fal/video.go` (`GenerateVideo`) to handle new request types and map models to their correct API endpoint paths.