### PR TITLE
fix text2video command context handling

### DIFF
--- a/internal/commands/text2video.go
+++ b/internal/commands/text2video.go
@@ -105,6 +105,9 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 				UserNick:        msgCtx.Nick,
 				UserID:          userID,
 				PriceUSD:        model.PriceUSD,
+				IsPM:            msgCtx.IsPM,
+				GC:              msgCtx.GC,
+				ModelName:       model.Name,
 			}
 
 			// Process the video

--- a/internal/video/types.go
+++ b/internal/video/types.go
@@ -16,6 +16,7 @@ type VideoRequest struct {
 	CFGScale                 *float64 // Optional, use pointer to track if set
 	PromptOptimizer          *bool    // Optional, for minimax-director model
 	ModelType                string   // "text2video" or "image2video"
+	ModelName                string   // Name of the model to use (set by handler)
 	Progress                 fal.ProgressCallback
 	UserNick                 string
 	UserID                   zkidentity.ShortID


### PR DESCRIPTION
closes #39 

Since the introduction of PM and GC contexts text2video did not consistently handle these contexts:

1. Per-user model selection
2. Group chat vs. private chat context handling:

- Fixes: per-user !setmodel for text2video now respected
- Fixes: status/result messages for text2video now sent to the correct context (PM or GC)
- Ensures consistent model selection and context handling across text2video, text2image, and text2speech