### PR TITLE
fix exchange rates caching for BTC and DCR

### DIFF
--- a/internal/commands/rate.go
+++ b/internal/commands/rate.go
@@ -50,9 +50,9 @@ func RateCommand() braibottypes.Command {
 			}
 
 			msg := fmt.Sprintf("Current Exchange Rates:\n• DCR: $%s USD\n• DCR: %s BTC\n• BTC: $%s USD",
-				utils.FormatThousands(dcrUsdPrice),
+				utils.FormatUSDThousands(dcrUsdPrice),
 				utils.FormatThousands(dcrBtcPrice),
-				utils.FormatThousands(btcUsdPrice))
+				utils.FormatUSDThousands(btcUsdPrice))
 			return sender.SendMessage(ctx, msgCtx, msg)
 		}),
 	}

--- a/internal/utils/currency.go
+++ b/internal/utils/currency.go
@@ -9,12 +9,13 @@ import (
 )
 
 var (
-	lastRateUpdate time.Time
-	dcrUsdRate     float64
-	dcrBtcRate     float64
-	btcUsdRate     float64
-	rateMutex      sync.RWMutex
-	rateCacheTime  = 10 * time.Minute
+	lastRateUpdate    time.Time
+	dcrUsdRate        float64
+	dcrBtcRate        float64
+	btcUsdRate        float64
+	rateMutex         sync.RWMutex
+	rateCacheTime     = 10 * time.Minute
+	lastBTCRateUpdate time.Time // Separate cache for BTC price
 )
 
 // GetDCRPrice gets the current DCR price in USD and BTC from CoinGecko
@@ -85,7 +86,7 @@ func GetDCRPrice() (float64, float64, error) {
 // GetBTCPrice gets the current BTC price in USD from CoinGecko
 func GetBTCPrice() (float64, error) {
 	rateMutex.RLock()
-	if time.Since(lastRateUpdate) < rateCacheTime {
+	if time.Since(lastBTCRateUpdate) < rateCacheTime {
 		rate := btcUsdRate
 		rateMutex.RUnlock()
 		return rate, nil
@@ -134,7 +135,7 @@ func GetBTCPrice() (float64, error) {
 	// Update cache
 	rateMutex.Lock()
 	btcUsdRate = usdPrice
-	lastRateUpdate = time.Now()
+	lastBTCRateUpdate = time.Now()
 	rateMutex.Unlock()
 
 	return usdPrice, nil

--- a/internal/utils/formatters.go
+++ b/internal/utils/formatters.go
@@ -158,6 +158,26 @@ func FormatThousands(n float64) string {
 	return intPart + "." + decPart
 }
 
+// FormatUSDThousands formats a float64 as USD with thousands separators and 2 decimal places.
+func FormatUSDThousands(n float64) string {
+	s := fmt.Sprintf("%.2f", n)
+	parts := strings.Split(s, ".")
+	intPart := parts[0]
+	decPart := parts[1]
+	negative := false
+	if strings.HasPrefix(intPart, "-") {
+		negative = true
+		intPart = intPart[1:]
+	}
+	for i := len(intPart) - 3; i > 0; i -= 3 {
+		intPart = intPart[:i] + "," + intPart[i:]
+	}
+	if negative {
+		intPart = "-" + intPart
+	}
+	return intPart + "." + decPart
+}
+
 // IsAudioNote checks if a message contains an audio note embed
 func IsAudioNote(message string) bool {
 	return strings.Contains(message, "--embed[alt=Audio note,type=audio/ogg")


### PR DESCRIPTION
Added a separate cache timestamp (lastBTCRateUpdate) for BTC price to prevent stale or zero values when fetching DCR price.

Introduced FormatUSDThousands to format USD prices with thousands separators and 2 decimal places.

Updated the !rate command output to use the new formatter for both DCR and BTC USD prices.