### PR TITLE
fix: add missing IsPM and GC fields to image2video VideoRequest

### DIFF
--- a/internal/commands/image2video.go
+++ b/internal/commands/image2video.go
@@ -154,6 +154,8 @@ func Image2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, imageService *vi
 				UserNick:        msgCtx.Nick,
 				UserID:          userID,
 				PriceUSD:        totalCost,
+				IsPM:            msgCtx.IsPM,
+				GC:              msgCtx.GC,
 			}
 
 			// Set the correct image URL field based on the model


### PR DESCRIPTION
Adds the missing IsPM and GC fields to the VideoRequest in the image2video command, so billing statements correctly reflect the message context.