### PR TITLE
add Grok Imagine Video text-to-video model

### DIFF
--- a/internal/commands/image2video.go
+++ b/internal/commands/image2video.go
@@ -71,7 +71,7 @@ func Image2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, imageService *vi
 
 			// Parse arguments using the video parser
 			parser := video.NewArgumentParser()
-			prompt, imageURL, duration, aspectRatio, negativePrompt, cfgScalePtr, promptOptimizerPtr, err := parser.Parse(args, true) // Expect Image URL, ignore promptOptimizer
+			prompt, imageURL, duration, aspectRatio, negativePrompt, cfgScalePtr, promptOptimizerPtr, _, err := parser.Parse(args, true) // Expect Image URL, ignore promptOptimizer
 			if err != nil {
 				return msgSender.SendMessage(ctx, msgCtx, fmt.Sprintf("Argument error: %v", err))
 			}

--- a/internal/commands/text2video.go
+++ b/internal/commands/text2video.go
@@ -68,7 +68,7 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 
 			// Parse arguments using the video parser
 			parser := video.NewArgumentParser()
-			prompt, _, duration, aspectRatio, negativePrompt, cfgScalePtr, promptOptimizerPtr, err := parser.Parse(args, false) // No Image URL expected
+			prompt, _, duration, aspectRatio, negativePrompt, cfgScalePtr, promptOptimizerPtr, resolution, err := parser.Parse(args, false) // No Image URL expected
 			if err != nil {
 				return msgSender.SendMessage(ctx, msgCtx, fmt.Sprintf("Argument error: %v", err))
 			}
@@ -108,7 +108,8 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 					modelDefault = 6
 				case "minimax/video-01", "minimax/video-01-director":
 					modelDefault = 6
-					// Add more models as needed
+				case "grok-imagine-video-text":
+					modelDefault = 6
 				}
 				if modelDefault > 0 {
 					durInt = modelDefault
@@ -134,6 +135,7 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 				Prompt:          prompt,
 				Duration:        duration,
 				AspectRatio:     aspectRatio,
+				Resolution:      resolution,
 				NegativePrompt:  negativePrompt,
 				CFGScale:        cfgScalePtr,
 				PromptOptimizer: promptOptimizerPtr,

--- a/internal/video/parser.go
+++ b/internal/video/parser.go
@@ -79,7 +79,7 @@ func (p *ArgumentParser) ParsePromptOptimizer(args []string) *bool {
 
 // Parse parses all arguments, separating prompt, image URL (optional), and options.
 // It returns the parsed values individually.
-func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imageURL, duration, aspectRatio, negativePrompt string, cfgScale *float64, promptOptimizer *bool, err error) {
+func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imageURL, duration, aspectRatio, negativePrompt string, cfgScale *float64, promptOptimizer *bool, resolution string, err error) {
 	var promptParts []string
 	// Set defaults
 	duration = "5"
@@ -87,6 +87,7 @@ func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imag
 	negativePrompt = "blur, distort, and low quality"
 	cfgScale = nil        // Default to nil, only set if parsed
 	promptOptimizer = nil // Default to nil
+	resolution = ""       // Default to empty, let model defaults apply
 
 	parsedArgs := make(map[int]bool) // Track indices consumed by flags
 	currentIndex := 0
@@ -197,6 +198,16 @@ func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imag
 				err = fmt.Errorf("missing value for %s", flag)
 				return
 			}
+		case "--resolution":
+			if value != "" {
+				resolution = value
+				parsedArgs[originalIndex] = true
+				parsedArgs[originalIndex+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
 		default:
 			// Unknown flag, treat as part of prompt later or ignore
 			i++
@@ -213,5 +224,5 @@ func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imag
 
 	// No final validation here anymore - that will happen in the FAL layer
 
-	return prompt, imageURL, duration, aspectRatio, negativePrompt, cfgScale, promptOptimizer, nil
+	return prompt, imageURL, duration, aspectRatio, negativePrompt, cfgScale, promptOptimizer, resolution, nil
 }

--- a/internal/video/service.go
+++ b/internal/video/service.go
@@ -418,7 +418,26 @@ func createFalVideoRequest(req *VideoRequest, modelName string) (interface{}, er
 		}
 		falReq.BaseVideoRequest.ImageURL = "" // Ensure base ImageURL is empty
 		return falReq, nil
-	// Add cases for other specific video models here
+	case "grok-imagine-video-text":
+		if base.ImageURL != "" {
+			return nil, fmt.Errorf("image_url is not supported for %s model", modelName)
+		}
+		duration := 0
+		if req.Duration != "" {
+			d, err := strconv.Atoi(req.Duration)
+			if err == nil && d > 0 {
+				duration = d
+			}
+		}
+
+		falReq := &fal.GrokImagineVideoTextRequest{
+			BaseVideoRequest: base,
+			Duration:         duration,
+			AspectRatio:      req.AspectRatio,
+			Resolution:       req.Resolution,
+		}
+		falReq.BaseVideoRequest.ImageURL = ""
+		return falReq, nil
 	default:
 		return nil, fmt.Errorf("unsupported or unhandled model for specific FAL video request creation: %s", modelName)
 	}

--- a/internal/video/types.go
+++ b/internal/video/types.go
@@ -12,6 +12,7 @@ type VideoRequest struct {
 	SubjectReferenceImageURL string   // Optional, used by minimax-subject-reference
 	Duration                 string   // Optional, defaults handled by FAL
 	AspectRatio              string   // Optional, defaults handled by FAL
+	Resolution               string   // Optional, defaults handled by FAL
 	NegativePrompt           string   // Optional, defaults handled by FAL
 	CFGScale                 *float64 // Optional, use pointer to track if set
 	PromptOptimizer          *bool    // Optional, for minimax-director model

--- a/pkg/fal/text_video_models.go
+++ b/pkg/fal/text_video_models.go
@@ -171,4 +171,21 @@ func init() {
 	registerModel(&minimaxHailuo02Model{})
 	registerModel(&hunyuanVideoModel{})
 	registerModel(&klingVideoV25TextModel{})
+	registerModel(&grokImagineVideoTextModel{})
+}
+
+// --- grok-imagine-video-text ---
+
+type grokImagineVideoTextModel struct{}
+
+func (m *grokImagineVideoTextModel) Define() Model {
+	return Model{
+		Name:             "grok-imagine-video-text",
+		Description:      "Grok Imagine Video - Text-to-video generation by xAI",
+		PriceUSD:         0.08,
+		Type:             "text2video",
+		PerSecondPricing: true,
+		HelpDoc:          "Usage: !text2video [prompt] [options]\n\n💰 **Price: $0.08 per video second**\nExample: A 6-second video will cost $0.48.\nTotal cost = price per second × duration.\n\nParameters:\n• prompt: Text description (required, max 4096 chars)\n• --duration: Video duration in seconds (1-15, default: 6)\n• --aspect: Aspect ratio: 16:9, 4:3, 3:2, 1:1, 2:3, 3:4, 9:16 (default: 16:9)\n• --resolution: 480p, 720p (default: 720p)",
+		Options:          &GrokImagineVideoTextOptions{Duration: 6, AspectRatio: "16:9", Resolution: "720p"},
+	}
 }

--- a/pkg/fal/types.go
+++ b/pkg/fal/types.go
@@ -1790,3 +1790,46 @@ type GrokImagineVideoRequest struct {
 	AspectRatio string `json:"aspect_ratio,omitempty"`
 	Resolution  string `json:"resolution,omitempty"`
 }
+
+// GrokImagineVideoTextOptions represents options for grok-imagine-video-text (text-to-video)
+type GrokImagineVideoTextOptions struct {
+	Duration    int    `json:"duration"`     // 1-15 seconds
+	AspectRatio string `json:"aspect_ratio"` // 16:9, 4:3, 3:2, 1:1, 2:3, 3:4, 9:16
+	Resolution  string `json:"resolution"`   // 480p, 720p
+}
+
+// GetDefaultValues returns default values for Grok Imagine Video Text options
+func (o *GrokImagineVideoTextOptions) GetDefaultValues() map[string]interface{} {
+	return map[string]interface{}{
+		"duration":     6,
+		"aspect_ratio": "16:9",
+		"resolution":   "720p",
+	}
+}
+
+// Validate validates the Grok Imagine Video Text options
+func (o *GrokImagineVideoTextOptions) Validate() error {
+	if o.Duration != 0 && (o.Duration < 1 || o.Duration > 15) {
+		return fmt.Errorf("invalid duration: %d (must be between 1 and 15)", o.Duration)
+	}
+	validAspectRatios := map[string]bool{
+		"16:9": true, "4:3": true, "3:2": true,
+		"1:1": true, "2:3": true, "3:4": true, "9:16": true, "": true,
+	}
+	if !validAspectRatios[o.AspectRatio] {
+		return fmt.Errorf("invalid aspect_ratio: %s (must be 16:9, 4:3, 3:2, 1:1, 2:3, 3:4, or 9:16)", o.AspectRatio)
+	}
+	validResolutions := map[string]bool{"480p": true, "720p": true, "": true}
+	if !validResolutions[o.Resolution] {
+		return fmt.Errorf("invalid resolution: %s (must be 480p or 720p)", o.Resolution)
+	}
+	return nil
+}
+
+// GrokImagineVideoTextRequest represents a request for grok-imagine-video-text (text-to-video)
+type GrokImagineVideoTextRequest struct {
+	BaseVideoRequest
+	Duration    int    `json:"duration,omitempty"`
+	AspectRatio string `json:"aspect_ratio,omitempty"`
+	Resolution  string `json:"resolution,omitempty"`
+}


### PR DESCRIPTION
Add grok-imagine-video-text model supporting text-to-video generation via the xAI Grok Imagine Video API at $0.08/second with per-second billing. Supports prompt, duration (1-15s), aspect ratio, and resolution (480p/720p) parameters. Also adds --resolution flag parsing to the argument parser.