### PR TITLE
add Seedance 2.0 models and !multi2video command

### DIFF
--- a/internal/commands/image2video.go
+++ b/internal/commands/image2video.go
@@ -71,7 +71,7 @@ func Image2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, imageService *vi
 
 			// Parse arguments using the video parser
 			parser := video.NewArgumentParser()
-			prompt, imageURL, duration, aspectRatio, negativePrompt, cfgScalePtr, promptOptimizerPtr, _, generateAudioPtr, endImageURL, err := parser.Parse(args, true) // Expect Image URL
+			prompt, imageURL, duration, aspectRatio, negativePrompt, cfgScalePtr, promptOptimizerPtr, resolution, generateAudioPtr, endImageURL, seedPtr, err := parser.Parse(args, true) // Expect Image URL
 			if err != nil {
 				return msgSender.SendMessage(ctx, msgCtx, fmt.Sprintf("Argument error: %v", err))
 			}
@@ -126,6 +126,8 @@ func Image2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, imageService *vi
 					modelDefault = 8
 				case "kling-video-v3-image", "kling-video-v3-pro-image":
 					modelDefault = 5
+				case "seedance-2.0-image":
+					modelDefault = 5
 				}
 				if modelDefault > 0 {
 					durInt = modelDefault
@@ -148,11 +150,13 @@ func Image2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, imageService *vi
 				Prompt:          prompt,
 				Duration:        duration,
 				AspectRatio:     aspectRatio,
+				Resolution:      resolution,
 				NegativePrompt:  negativePrompt,
 				CFGScale:        cfgScalePtr,
 				PromptOptimizer: promptOptimizerPtr,
 				GenerateAudio:   generateAudioPtr,
 				EndImageURL:     endImageURL,
+				Seed:            seedPtr,
 				ModelType:       "image2video",
 				Progress:        progress,
 				UserNick:        msgCtx.Nick,

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -58,5 +58,7 @@ func InitializeCommands(dbManager *database.DBManager, cfg *config.BotConfig, bo
 
 	registry.Register(Video2VideoCommand(bot, cfg, videoService, debug))
 
+	registry.Register(Multi2VideoCommand(bot, cfg, videoService, debug))
+
 	return registry
 }

--- a/internal/commands/multi2video.go
+++ b/internal/commands/multi2video.go
@@ -15,21 +15,22 @@ import (
 	botconfig "github.com/vctt94/bisonbotkit/config"
 )
 
-// Text2VideoCommand returns the text2video command
-// It now requires a VideoService instance.
-func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *video.VideoService, debug bool) braibottypes.Command {
+// Multi2VideoCommand returns the multi2video (reference-to-video) command.
+// It accepts a prompt plus any combination of reference images (up to 9),
+// videos (up to 3), and audio files (up to 3).
+func Multi2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *video.VideoService, debug bool) braibottypes.Command {
 	// Get the current model to use its description
-	model, exists := faladapter.GetCurrentModel("text2video", "") // Empty string for global default
+	model, exists := faladapter.GetCurrentModel("multi2video", "")
 	if !exists {
 		model = fal.Model{
-			Name:        "text2video",
-			Description: "Generate a video from text",
+			Name:        "multi2video",
+			Description: "Generate a video from a prompt plus reference images, videos, and audio",
 		}
 	}
-	description := fmt.Sprintf("%s. Usage: !text2video [prompt] [--duration 5] [--aspect 16:9]", model.Description)
+	description := fmt.Sprintf("%s. Usage: !multi2video [prompt] [--image1..9 url] [--video1..3 url] [--audio1..3 url] [--options]", model.Description)
 
 	return braibottypes.Command{
-		Name:        "text2video",
+		Name:        "multi2video",
 		Description: description,
 		Category:    "AI Generation",
 		Handler: braibottypes.CommandFunc(func(ctx context.Context, msgCtx braibottypes.MessageContext, args []string, sender *braibottypes.MessageSender, db braibottypes.DBManagerInterface) error {
@@ -44,9 +45,9 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 					uid.FromBytes(msgCtx.Uid)
 					userIDStr = uid.String()
 				}
-				model, exists := faladapter.GetCurrentModel("text2video", userIDStr)
+				model, exists := faladapter.GetCurrentModel("multi2video", userIDStr)
 				if !exists {
-					return msgSender.SendMessage(ctx, msgCtx, "Error: Default text2video model not found.")
+					return msgSender.SendMessage(ctx, msgCtx, "Error: Default multi2video model not found.")
 				}
 
 				// Get user ID
@@ -54,12 +55,12 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 				userID.FromBytes(msgCtx.Uid)
 
 				// Format header using utility function
-				header := utils.FormatCommandHelpHeader("text2video", model, userID, db)
+				header := utils.FormatCommandHelpHeader("multi2video", model, userID, db)
 
 				// Get help doc
 				helpDoc := model.HelpDoc
 				if helpDoc == "" {
-					helpDoc = "Usage: !text2video [prompt] [--options...]\n(No specific documentation available for this model.)"
+					helpDoc = "Usage: !multi2video [prompt] [--image1..9 url] [--video1..3 url] [--audio1..3 url] [--options...]\n(No specific documentation available for this model.)"
 				}
 
 				// Send combined header and help doc
@@ -68,12 +69,18 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 
 			// Parse arguments using the video parser
 			parser := video.NewArgumentParser()
-			prompt, _, duration, aspectRatio, negativePrompt, cfgScalePtr, promptOptimizerPtr, resolution, generateAudioPtr, _, seedPtr, err := parser.Parse(args, false) // No Image URL expected
+			prompt, duration, aspectRatio, resolution, generateAudioPtr, seedPtr, imageURLs, videoURLs, audioURLs, err := parser.ParseMulti2Video(args)
 			if err != nil {
 				return msgSender.SendMessage(ctx, msgCtx, fmt.Sprintf("Argument error: %v", err))
 			}
 			if prompt == "" {
 				return msgSender.SendMessage(ctx, msgCtx, "Please provide a text prompt describing the desired video.")
+			}
+			if len(imageURLs) == 0 && len(videoURLs) == 0 && len(audioURLs) == 0 {
+				return msgSender.SendMessage(ctx, msgCtx, "At least one reference input (--image1, --video1, or --audio1) is required. For a purely text-driven video, use !text2video instead.")
+			}
+			if len(audioURLs) > 0 && len(imageURLs) == 0 && len(videoURLs) == 0 {
+				return msgSender.SendMessage(ctx, msgCtx, "Reference audio requires at least one reference image or video.")
 			}
 
 			// Get model configuration
@@ -83,46 +90,32 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 				uid.FromBytes(msgCtx.Uid)
 				userIDStr = uid.String()
 			}
-			model, exists := faladapter.GetCurrentModel("text2video", userIDStr)
+			model, exists := faladapter.GetCurrentModel("multi2video", userIDStr)
 			if !exists {
-				return msgSender.SendErrorMessage(ctx, msgCtx, fmt.Errorf("no default model found for text2video"))
+				return msgSender.SendErrorMessage(ctx, msgCtx, fmt.Errorf("no default model found for multi2video"))
 			}
 
-			// Determine effective duration
+			// Determine effective duration for per-second pricing
 			originalUserDuration := duration
 			durInt := 0
 			if duration != "" {
 				durInt, err = strconv.Atoi(duration)
 				if err != nil || durInt <= 0 {
-					durInt = 0 // fallback to check model default
+					durInt = 0
 				}
 			}
 			if durInt == 0 {
-				// Try to get model default duration (if available)
 				modelDefault := 0
-				// Check for known model default durations
 				switch model.Name {
-				case "kling-video-text":
-					modelDefault = 5
-				case "minimax/hailuo-02":
-					modelDefault = 6
-				case "minimax/video-01", "minimax/video-01-director":
-					modelDefault = 6
-				case "grok-imagine-video-text":
-					modelDefault = 6
-				case "kling-video-v3-text", "kling-video-v3-pro-text":
-					modelDefault = 5
-				case "kling-video-o3-text", "kling-video-o3-pro-text":
-					modelDefault = 5
-				case "seedance-2.0-text":
+				case "seedance-2.0-reference":
 					modelDefault = 5
 				}
 				if modelDefault > 0 {
 					durInt = modelDefault
 					duration = strconv.Itoa(modelDefault)
 				} else {
-					durInt = 6 // fallback to hardcoded default
-					duration = "6"
+					durInt = 5
+					duration = "5"
 				}
 			}
 
@@ -132,37 +125,38 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 			}
 
 			// Create progress callback
-			progress := NewCommandProgressCallback(bot, msgCtx.Nick, msgCtx.Sender, "text2video", msgCtx.IsPM, msgCtx.GC)
+			progress := NewCommandProgressCallback(bot, msgCtx.Nick, msgCtx.Sender, "multi2video", msgCtx.IsPM, msgCtx.GC)
 
 			// Create video request using parsed values
 			var userID zkidentity.ShortID
 			userID.FromBytes(msgCtx.Uid)
 			req := &video.VideoRequest{
-				Prompt:          prompt,
-				Duration:        duration,
-				AspectRatio:     aspectRatio,
-				Resolution:      resolution,
-				NegativePrompt:  negativePrompt,
-				CFGScale:        cfgScalePtr,
-				PromptOptimizer: promptOptimizerPtr,
-				GenerateAudio:   generateAudioPtr,
-				Seed:            seedPtr,
-				ModelType:       "text2video",
-				Progress:        progress,
-				UserNick:        msgCtx.Nick,
-				UserID:          userID,
-				PriceUSD:        totalCost,
-				IsPM:            msgCtx.IsPM,
-				GC:              msgCtx.GC,
-				ModelName:       model.Name,
+				Prompt:        prompt,
+				Duration:      duration,
+				AspectRatio:   aspectRatio,
+				Resolution:    resolution,
+				GenerateAudio: generateAudioPtr,
+				ImageURLs:     imageURLs,
+				VideoURLs:     videoURLs,
+				AudioURLs:     audioURLs,
+				Seed:          seedPtr,
+				ModelType:     "multi2video",
+				Progress:      progress,
+				UserNick:      msgCtx.Nick,
+				UserID:        userID,
+				PriceUSD:      totalCost,
+				IsPM:          msgCtx.IsPM,
+				GC:            msgCtx.GC,
+				ModelName:     model.Name,
 			}
 
 			// Inform user of pricing and total cost
 			if msgCtx.IsPM {
 				if model.PerSecondPricing {
 					msg := fmt.Sprintf(
-						"Model: %s\n💰 Price: $%.2f per video second\nRequested duration: %d seconds\nTotal cost: $%.2f = $%.2f/sec × %d sec",
+						"Model: %s\n💰 Price: $%.2f per video second\nRequested duration: %d seconds\nTotal cost: $%.2f = $%.2f/sec × %d sec\nReference inputs: %d image(s), %d video(s), %d audio(s)",
 						model.Name, model.PriceUSD, durInt, totalCost, model.PriceUSD, durInt,
+						len(imageURLs), len(videoURLs), len(audioURLs),
 					)
 					if originalUserDuration == "" {
 						msg += fmt.Sprintf("\n(No duration specified, using default duration of %d seconds.)", durInt)
@@ -176,11 +170,11 @@ func Text2VideoCommand(bot *kit.Bot, cfg *botconfig.BotConfig, videoService *vid
 				}
 			}
 
-			// Process the video
+			// Generate video using the service
 			result, err := videoService.GenerateVideo(ctx, req)
 
 			// Handle result/error using the utility function
-			if handleErr := utils.HandleServiceResultOrError(ctx, bot, msgCtx, "text2video", result, err); handleErr != nil {
+			if handleErr := utils.HandleServiceResultOrError(ctx, bot, msgCtx, "multi2video", result, err); handleErr != nil {
 				return handleErr
 			}
 

--- a/internal/commands/progress.go
+++ b/internal/commands/progress.go
@@ -114,7 +114,7 @@ func (c *CommandProgressCallback) OnProgress(status string) {
 	if status == "IN_PROGRESS" && time.Since(c.lastSpecialMessage) >= c.specialMessageInterval {
 		var message string
 		switch c.cmdType {
-		case "image2video", "video2video":
+		case "image2video", "video2video", "multi2video":
 			message = "The video generation is in process\nVideo generation can take a long time, up to 20 minutes\nDuring the process the bot does not respond to any commands, please be patient"
 		case "image2image":
 			message = "The image generation is in process\nImage generation can take a few minutes\nDuring the process the bot does not respond to any commands, please be patient"

--- a/internal/video/parser.go
+++ b/internal/video/parser.go
@@ -79,7 +79,7 @@ func (p *ArgumentParser) ParsePromptOptimizer(args []string) *bool {
 
 // Parse parses all arguments, separating prompt, image URL (optional), and options.
 // It returns the parsed values individually.
-func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imageURL, duration, aspectRatio, negativePrompt string, cfgScale *float64, promptOptimizer *bool, resolution string, generateAudio *bool, endImageURL string, err error) {
+func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imageURL, duration, aspectRatio, negativePrompt string, cfgScale *float64, promptOptimizer *bool, resolution string, generateAudio *bool, endImageURL string, seed *int64, err error) {
 	var promptParts []string
 	// Set defaults
 	duration = "5"
@@ -88,6 +88,7 @@ func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imag
 	cfgScale = nil        // Default to nil, only set if parsed
 	promptOptimizer = nil // Default to nil
 	resolution = ""       // Default to empty, let model defaults apply
+	seed = nil            // Default to nil, only set if parsed
 
 	parsedArgs := make(map[int]bool) // Track indices consumed by flags
 	currentIndex := 0
@@ -241,6 +242,21 @@ func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imag
 				err = fmt.Errorf("missing value for %s", flag)
 				return
 			}
+		case "--seed":
+			if value != "" {
+				s, parseErr := strconv.ParseInt(value, 10, 64)
+				if parseErr != nil {
+					err = fmt.Errorf("invalid value for %s: %s (must be an integer)", flag, value)
+					return
+				}
+				seed = &s
+				parsedArgs[originalIndex] = true
+				parsedArgs[originalIndex+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
 		default:
 			// Unknown flag, treat as part of prompt later or ignore
 			i++
@@ -257,7 +273,149 @@ func (p *ArgumentParser) Parse(args []string, expectImageURL bool) (prompt, imag
 
 	// No final validation here anymore - that will happen in the FAL layer
 
-	return prompt, imageURL, duration, aspectRatio, negativePrompt, cfgScale, promptOptimizer, resolution, generateAudio, endImageURL, nil
+	return prompt, imageURL, duration, aspectRatio, negativePrompt, cfgScale, promptOptimizer, resolution, generateAudio, endImageURL, seed, nil
+}
+
+// ParseMulti2Video parses arguments for the multi2video (reference-to-video) command.
+// Usage: !multi2video [prompt text] [--image1..9 url] [--video1..3 url] [--audio1..3 url] [--duration N] [--aspect auto] [--resolution 720p] [--audio true|false] [--seed N]
+func (p *ArgumentParser) ParseMulti2Video(args []string) (prompt, duration, aspectRatio, resolution string, generateAudio *bool, seed *int64, imageURLs, videoURLs, audioURLs []string, err error) {
+	if len(args) == 0 {
+		err = fmt.Errorf("prompt is required")
+		return
+	}
+
+	var promptParts []string
+	parsedArgs := make(map[int]bool)
+
+	// Parse flags
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "--") {
+			i++
+			continue
+		}
+
+		flag := strings.ToLower(arg)
+
+		// Check for value
+		var value string
+		if i+1 < len(args) {
+			value = args[i+1]
+		}
+
+		switch flag {
+		case "--image1", "--image2", "--image3", "--image4",
+			"--image5", "--image6", "--image7", "--image8", "--image9":
+			if value != "" {
+				imageURLs = append(imageURLs, value)
+				parsedArgs[i] = true
+				parsedArgs[i+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
+		case "--video1", "--video2", "--video3":
+			if value != "" {
+				videoURLs = append(videoURLs, value)
+				parsedArgs[i] = true
+				parsedArgs[i+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
+		case "--audio1", "--audio2", "--audio3":
+			if value != "" {
+				audioURLs = append(audioURLs, value)
+				parsedArgs[i] = true
+				parsedArgs[i+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
+		case "--duration":
+			if value != "" {
+				duration = strings.TrimSuffix(value, "s")
+				parsedArgs[i] = true
+				parsedArgs[i+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
+		case "--aspect":
+			if value != "" {
+				aspectRatio = value
+				parsedArgs[i] = true
+				parsedArgs[i+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
+		case "--resolution":
+			if value != "" {
+				resolution = value
+				parsedArgs[i] = true
+				parsedArgs[i+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
+		case "--audio":
+			if value != "" {
+				valStr := strings.ToLower(value)
+				if valStr == "true" {
+					result := true
+					generateAudio = &result
+				} else if valStr == "false" {
+					result := false
+					generateAudio = &result
+				} else {
+					err = fmt.Errorf("invalid value for %s: %s (must be true or false)", flag, value)
+					return
+				}
+				parsedArgs[i] = true
+				parsedArgs[i+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
+		case "--seed":
+			if value != "" {
+				s, parseErr := strconv.ParseInt(value, 10, 64)
+				if parseErr != nil {
+					err = fmt.Errorf("invalid value for %s: %s (must be an integer)", flag, value)
+					return
+				}
+				seed = &s
+				parsedArgs[i] = true
+				parsedArgs[i+1] = true
+				i += 2
+			} else {
+				err = fmt.Errorf("missing value for %s", flag)
+				return
+			}
+		default:
+			// Unknown flag, treat as part of prompt
+			i++
+		}
+	}
+
+	// Collect prompt parts from remaining args
+	for i, arg := range args {
+		if !parsedArgs[i] {
+			promptParts = append(promptParts, arg)
+		}
+	}
+	prompt = strings.Join(promptParts, " ")
+
+	return
 }
 
 // ParseVideo2Video parses arguments for the video2video command.

--- a/internal/video/service.go
+++ b/internal/video/service.go
@@ -210,8 +210,9 @@ func (s *VideoService) validateRequest(req *VideoRequest) error {
 	case "kling-video-text", "kling-video-image",
 		"kling-video-v3-text", "kling-video-v3-pro-text",
 		"kling-video-v3-image", "kling-video-v3-pro-image",
-		"kling-video-o3-text", "kling-video-o3-pro-text":
-		// Ensure duration does NOT have 's' suffix for Kling
+		"kling-video-o3-text", "kling-video-o3-pro-text",
+		"seedance-2.0-image", "seedance-2.0-text", "seedance-2.0-reference":
+		// Ensure duration does NOT have 's' suffix for Kling / Seedance
 		if strings.HasSuffix(req.Duration, "s") {
 			req.Duration = strings.TrimSuffix(req.Duration, "s") // Modify in place
 		}
@@ -224,6 +225,32 @@ func (s *VideoService) validateRequest(req *VideoRequest) error {
 		case "kling-video-o3-edit", "kling-video-o3-pro-edit":
 			if req.VideoURL == "" {
 				return fmt.Errorf("video URL is required for model %s", model.Name)
+			}
+		}
+	}
+
+	// For multi2video (reference-to-video), enforce per-modality limits and the "audio requires image/video" constraint.
+	if req.ModelType == "multi2video" {
+		switch model.Name {
+		case "seedance-2.0-reference":
+			totalRefs := len(req.ImageURLs) + len(req.VideoURLs) + len(req.AudioURLs)
+			if totalRefs == 0 {
+				return fmt.Errorf("at least one reference input (--image, --video, or --audio) is required for %s", model.Name)
+			}
+			if totalRefs > 12 {
+				return fmt.Errorf("total reference files must not exceed 12 (got %d)", totalRefs)
+			}
+			if len(req.ImageURLs) > 9 {
+				return fmt.Errorf("max 9 reference images (got %d)", len(req.ImageURLs))
+			}
+			if len(req.VideoURLs) > 3 {
+				return fmt.Errorf("max 3 reference videos (got %d)", len(req.VideoURLs))
+			}
+			if len(req.AudioURLs) > 3 {
+				return fmt.Errorf("max 3 reference audio files (got %d)", len(req.AudioURLs))
+			}
+			if len(req.AudioURLs) > 0 && len(req.ImageURLs)+len(req.VideoURLs) == 0 {
+				return fmt.Errorf("reference audio requires at least one reference image or video")
 			}
 		}
 	}
@@ -489,6 +516,51 @@ func createFalVideoRequest(req *VideoRequest, modelName string) (interface{}, er
 		}
 		falReq.BaseVideoRequest.Model = modelName
 		falReq.BaseVideoRequest.ImageURL = "" // Ensure empty for text2video
+		return falReq, nil
+	case "seedance-2.0-image":
+		if base.ImageURL == "" {
+			return nil, fmt.Errorf("image_url is required for %s model", modelName)
+		}
+		falReq := &fal.SeedanceRequest{
+			BaseVideoRequest: base,
+			Duration:         req.Duration, // Already stripped of 's' suffix by validateRequest
+			AspectRatio:      req.AspectRatio,
+			Resolution:       req.Resolution,
+			GenerateAudio:    req.GenerateAudio,
+			EndImageURL:      req.EndImageURL,
+			Seed:             req.Seed,
+			EndUserID:        req.UserID.String(), // ByteDance requires this for copyright tracking
+		}
+		falReq.BaseVideoRequest.Model = modelName
+		return falReq, nil
+	case "seedance-2.0-text":
+		falReq := &fal.SeedanceRequest{
+			BaseVideoRequest: base,
+			Duration:         req.Duration, // Already stripped of 's' suffix by validateRequest
+			AspectRatio:      req.AspectRatio,
+			Resolution:       req.Resolution,
+			GenerateAudio:    req.GenerateAudio,
+			Seed:             req.Seed,
+			EndUserID:        req.UserID.String(), // ByteDance requires this for copyright tracking
+		}
+		falReq.BaseVideoRequest.Model = modelName
+		falReq.BaseVideoRequest.ImageURL = "" // Ensure empty for text2video
+		return falReq, nil
+	case "seedance-2.0-reference":
+		falReq := &fal.SeedanceReferenceRequest{
+			BaseVideoRequest: base,
+			Duration:         req.Duration, // Already stripped of 's' suffix by validateRequest
+			AspectRatio:      req.AspectRatio,
+			Resolution:       req.Resolution,
+			GenerateAudio:    req.GenerateAudio,
+			ImageURLs:        req.ImageURLs,
+			VideoURLs:        req.VideoURLs,
+			AudioURLs:        req.AudioURLs,
+			Seed:             req.Seed,
+			EndUserID:        req.UserID.String(), // ByteDance requires this for copyright tracking
+		}
+		falReq.BaseVideoRequest.Model = modelName
+		falReq.BaseVideoRequest.ImageURL = "" // Not used; references come from the URL slices
 		return falReq, nil
 	case "kling-video-o3-edit", "kling-video-o3-pro-edit":
 		if req.VideoURL == "" {

--- a/internal/video/types.go
+++ b/internal/video/types.go
@@ -20,7 +20,10 @@ type VideoRequest struct {
 	EndImageURL              string   // Optional, for Kling v3 image2video end frame
 	VideoURL                 string   // Required for video2video edit models
 	KeepAudio                *bool    // Optional, for O3 edit (default: true)
-	ImageURLs                []string // Optional, up to 4 reference images for O3 edit
+	ImageURLs                []string // Optional, up to 4 reference images for O3 edit / up to 9 for Seedance multi2video
+	VideoURLs                []string // Optional, up to 3 reference videos for Seedance multi2video
+	AudioURLs                []string // Optional, up to 3 reference audio files for Seedance multi2video
+	Seed                     *int64   // Optional, for reproducibility (Seedance 2.0)
 	ModelType                string   // "text2video" or "image2video"
 	ModelName                string   // Name of the model to use (set by handler)
 	Progress                 fal.ProgressCallback

--- a/pkg/fal/image_video_models.go
+++ b/pkg/fal/image_video_models.go
@@ -267,6 +267,28 @@ func (m *klingVideoV3ProImageModel) Define() Model {
 	}
 }
 
+// --- seedance-2.0-image ---
+
+type seedanceImageModel struct{}
+
+func (m *seedanceImageModel) Define() Model {
+	defaultAudio := true
+	return Model{
+		Name:             "seedance-2.0-image",
+		Description:      "ByteDance Seedance 2.0 Image-to-Video - Realistic motion with native audio generation",
+		PriceUSD:         0.35, // $0.35 per second (flat rate; fal charges $0.3024/s at 720p and $0.2419/s at 480p)
+		Type:             "image2video",
+		PerSecondPricing: true,
+		HelpDoc:          "Usage: !image2video [image_url] [prompt] [options]\n\n💰 **Price: $0.35 per second**\nExample: A 5-second video will cost $1.75.\nTotal cost = price per second × duration.\n\nParameters:\n• image_url: URL of the source image (required)\n• prompt: Description of the desired motion/action (required)\n• --duration: Video duration in seconds (4-15, default: 5)\n• --aspect: Aspect ratio (auto, 21:9, 16:9, 4:3, 1:1, 3:4, 9:16). Default: auto\n• --resolution: Video resolution (480p, 720p). Default: 720p\n• --audio: Enable audio generation (default: true)\n• --end_image: URL of end frame image (optional transition)\n• --seed: Seed for reproducibility (optional)",
+		Options: &SeedanceOptions{
+			Duration:      "5",
+			AspectRatio:   "auto",
+			Resolution:    "720p",
+			GenerateAudio: &defaultAudio,
+		},
+	}
+}
+
 func init() {
 	registerModel(&veo2Model{})
 	registerModel(&klingVideoImageModel{})
@@ -280,4 +302,5 @@ func init() {
 	registerModel(&grokImagineVideoModel{})
 	registerModel(&klingVideoV3ImageModel{})
 	registerModel(&klingVideoV3ProImageModel{})
+	registerModel(&seedanceImageModel{})
 }

--- a/pkg/fal/models.go
+++ b/pkg/fal/models.go
@@ -108,4 +108,5 @@ func init() {
 	setDefaultModel("text2video", "kling-video-text")
 	setDefaultModel("audio2text", "elevenlabs/speech-to-text/scribe-v2")
 	setDefaultModel("video2video", "kling-video-o3-edit")
+	setDefaultModel("multi2video", "seedance-2.0-reference")
 }

--- a/pkg/fal/multi_video_models.go
+++ b/pkg/fal/multi_video_models.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package fal
+
+// --- seedance-2.0-reference ---
+
+type seedanceReferenceModel struct{}
+
+func (m *seedanceReferenceModel) Define() Model {
+	defaultAudio := true
+	return Model{
+		Name:             "seedance-2.0-reference",
+		Description:      "ByteDance Seedance 2.0 Reference-to-Video - Generate video from text plus reference images, videos, and audio",
+		PriceUSD:         0.35, // $0.35 per second (flat rate; fal charges $0.3024/s at 720p without videos, $0.1814/s with videos)
+		Type:             "multi2video",
+		PerSecondPricing: true,
+		HelpDoc:          "Usage: !multi2video [prompt] [options]\n\n💰 **Price: $0.35 per second**\nExample: A 5-second video will cost $1.75.\nTotal cost = price per second × duration.\n\nParameters:\n• prompt: Text description of the desired video (required)\n• --image1..--image9: Reference image URLs (up to 9, JPEG/PNG/WebP, max 30MB each)\n• --video1..--video3: Reference video URLs (up to 3, MP4/MOV, <50MB total)\n• --audio1..--audio3: Reference audio URLs (up to 3, MP3/WAV, max 15MB each)\n• --duration: Video duration in seconds (4-15, default: 5)\n• --aspect: Aspect ratio (auto, 21:9, 16:9, 4:3, 1:1, 3:4, 9:16). Default: auto\n• --resolution: Video resolution (480p, 720p). Default: 720p\n• --audio: Enable generated audio output (default: true)\n• --seed: Seed for reproducibility (optional)\n\nConstraints:\n• At least one reference input (image, video, or audio) is required\n• Total reference files must not exceed 12\n• Reference audio requires at least one reference image or video",
+		Options: &SeedanceReferenceOptions{
+			Duration:      "5",
+			AspectRatio:   "auto",
+			Resolution:    "720p",
+			GenerateAudio: &defaultAudio,
+		},
+	}
+}
+
+func init() {
+	registerModel(&seedanceReferenceModel{})
+}

--- a/pkg/fal/text_video_models.go
+++ b/pkg/fal/text_video_models.go
@@ -255,6 +255,28 @@ func (m *klingVideoO3ProTextModel) Define() Model {
 	}
 }
 
+// --- seedance-2.0-text ---
+
+type seedanceTextModel struct{}
+
+func (m *seedanceTextModel) Define() Model {
+	defaultAudio := true
+	return Model{
+		Name:             "seedance-2.0-text",
+		Description:      "ByteDance Seedance 2.0 Text-to-Video - Realistic motion with native audio generation",
+		PriceUSD:         0.35, // $0.35 per second (flat rate; fal charges $0.3034/s at 720p)
+		Type:             "text2video",
+		PerSecondPricing: true,
+		HelpDoc:          "Usage: !text2video [prompt] [options]\n\n💰 **Price: $0.35 per second**\nExample: A 5-second video will cost $1.75.\nTotal cost = price per second × duration.\n\nParameters:\n• prompt: Text description of the desired video (required)\n• --duration: Video duration in seconds (4-15, default: 5)\n• --aspect: Aspect ratio (auto, 21:9, 16:9, 4:3, 1:1, 3:4, 9:16). Default: auto\n• --resolution: Video resolution (480p, 720p). Default: 720p\n• --audio: Enable audio generation (default: true)\n• --seed: Seed for reproducibility (optional)",
+		Options: &SeedanceOptions{
+			Duration:      "5",
+			AspectRatio:   "auto",
+			Resolution:    "720p",
+			GenerateAudio: &defaultAudio,
+		},
+	}
+}
+
 func init() {
 	registerModel(&minimaxHailuo02Model{})
 	registerModel(&hunyuanVideoModel{})
@@ -264,6 +286,7 @@ func init() {
 	registerModel(&klingVideoV3ProTextModel{})
 	registerModel(&klingVideoO3TextModel{})
 	registerModel(&klingVideoO3ProTextModel{})
+	registerModel(&seedanceTextModel{})
 }
 
 // --- grok-imagine-video-text ---

--- a/pkg/fal/types.go
+++ b/pkg/fal/types.go
@@ -1955,3 +1955,115 @@ type KlingVideoO3EditRequest struct {
 	ImageURLs        []string       `json:"image_urls,omitempty"`
 	KeepAudio        *bool          `json:"keep_audio,omitempty"`
 }
+
+// ==================== Seedance 2.0 (ByteDance, Text2Video + Image2Video) ====================
+
+// SeedanceOptions represents options for bytedance/seedance-2.0 text-to-video and image-to-video
+type SeedanceOptions struct {
+	Duration      string `json:"duration,omitempty"`       // "auto" or "4"-"15" seconds. Default: "5"
+	AspectRatio   string `json:"aspect_ratio,omitempty"`   // auto, 21:9, 16:9, 4:3, 1:1, 3:4, 9:16. Default: auto
+	Resolution    string `json:"resolution,omitempty"`     // 480p, 720p. Default: 720p
+	GenerateAudio *bool  `json:"generate_audio,omitempty"` // Default: true
+}
+
+// GetDefaultValues returns default values for Seedance 2.0 options
+func (o *SeedanceOptions) GetDefaultValues() map[string]interface{} {
+	defaultAudio := true
+	return map[string]interface{}{
+		"duration":       "5",
+		"aspect_ratio":   "auto",
+		"resolution":     "720p",
+		"generate_audio": &defaultAudio,
+	}
+}
+
+// Validate validates Seedance 2.0 options
+func (o *SeedanceOptions) Validate() error {
+	validAspectRatios := map[string]bool{
+		"auto": true, "21:9": true, "16:9": true, "4:3": true,
+		"1:1": true, "3:4": true, "9:16": true, "": true,
+	}
+	if !validAspectRatios[o.AspectRatio] {
+		return fmt.Errorf("invalid aspect_ratio: %s (must be auto, 21:9, 16:9, 4:3, 1:1, 3:4, or 9:16)", o.AspectRatio)
+	}
+	validResolutions := map[string]bool{"480p": true, "720p": true, "": true}
+	if !validResolutions[o.Resolution] {
+		return fmt.Errorf("invalid resolution: %s (must be 480p or 720p)", o.Resolution)
+	}
+	if o.Duration != "" && o.Duration != "auto" {
+		dur, err := strconv.Atoi(o.Duration)
+		if err != nil || dur < 4 || dur > 15 {
+			return fmt.Errorf("invalid duration: %s (must be auto or integer between 4 and 15 seconds)", o.Duration)
+		}
+	}
+	return nil
+}
+
+// SeedanceRequest represents a request for bytedance/seedance-2.0 (text or image to video)
+type SeedanceRequest struct {
+	BaseVideoRequest
+	Duration      string `json:"duration,omitempty"`
+	AspectRatio   string `json:"aspect_ratio,omitempty"`
+	Resolution    string `json:"resolution,omitempty"`
+	GenerateAudio *bool  `json:"generate_audio,omitempty"`
+	EndImageURL   string `json:"end_image_url,omitempty"` // image2video only
+	Seed          *int64 `json:"seed,omitempty"`
+	EndUserID     string `json:"end_user_id,omitempty"` // Required by ByteDance for copyright tracking
+}
+
+// ==================== Seedance 2.0 Reference-to-Video (ByteDance, multi-modal refs) ====================
+
+// SeedanceReferenceOptions represents options for bytedance/seedance-2.0/reference-to-video
+type SeedanceReferenceOptions struct {
+	Duration      string `json:"duration,omitempty"`       // "auto" or "4"-"15" seconds. Default: "5"
+	AspectRatio   string `json:"aspect_ratio,omitempty"`   // auto, 21:9, 16:9, 4:3, 1:1, 3:4, 9:16. Default: auto
+	Resolution    string `json:"resolution,omitempty"`     // 480p, 720p. Default: 720p
+	GenerateAudio *bool  `json:"generate_audio,omitempty"` // Default: true
+}
+
+// GetDefaultValues returns default values for Seedance 2.0 reference-to-video options
+func (o *SeedanceReferenceOptions) GetDefaultValues() map[string]interface{} {
+	defaultAudio := true
+	return map[string]interface{}{
+		"duration":       "5",
+		"aspect_ratio":   "auto",
+		"resolution":     "720p",
+		"generate_audio": &defaultAudio,
+	}
+}
+
+// Validate validates Seedance 2.0 reference-to-video options
+func (o *SeedanceReferenceOptions) Validate() error {
+	validAspectRatios := map[string]bool{
+		"auto": true, "21:9": true, "16:9": true, "4:3": true,
+		"1:1": true, "3:4": true, "9:16": true, "": true,
+	}
+	if !validAspectRatios[o.AspectRatio] {
+		return fmt.Errorf("invalid aspect_ratio: %s (must be auto, 21:9, 16:9, 4:3, 1:1, 3:4, or 9:16)", o.AspectRatio)
+	}
+	validResolutions := map[string]bool{"480p": true, "720p": true, "": true}
+	if !validResolutions[o.Resolution] {
+		return fmt.Errorf("invalid resolution: %s (must be 480p or 720p)", o.Resolution)
+	}
+	if o.Duration != "" && o.Duration != "auto" {
+		dur, err := strconv.Atoi(o.Duration)
+		if err != nil || dur < 4 || dur > 15 {
+			return fmt.Errorf("invalid duration: %s (must be auto or integer between 4 and 15 seconds)", o.Duration)
+		}
+	}
+	return nil
+}
+
+// SeedanceReferenceRequest represents a request for bytedance/seedance-2.0/reference-to-video
+type SeedanceReferenceRequest struct {
+	BaseVideoRequest
+	Duration      string   `json:"duration,omitempty"`
+	AspectRatio   string   `json:"aspect_ratio,omitempty"`
+	Resolution    string   `json:"resolution,omitempty"`
+	GenerateAudio *bool    `json:"generate_audio,omitempty"`
+	ImageURLs     []string `json:"image_urls,omitempty"` // Up to 9 reference images
+	VideoURLs     []string `json:"video_urls,omitempty"` // Up to 3 reference videos
+	AudioURLs     []string `json:"audio_urls,omitempty"` // Up to 3 reference audio files
+	Seed          *int64   `json:"seed,omitempty"`
+	EndUserID     string   `json:"end_user_id,omitempty"` // Required by ByteDance for copyright tracking
+}

--- a/pkg/fal/video.go
+++ b/pkg/fal/video.go
@@ -687,6 +687,177 @@ func (c *Client) GenerateVideo(ctx context.Context, req interface{}) (*VideoResp
 		if r.Prompt == "" {
 			delete(reqBody, "prompt")
 		}
+	case *SeedanceRequest:
+		modelName = r.BaseVideoRequest.Model
+		// Map model name to endpoint and modality
+		var modelType string
+		switch modelName {
+		case "seedance-2.0-image":
+			endpoint = "https://queue.fal.run/bytedance/seedance-2.0/image-to-video"
+			modelType = "image2video"
+		case "seedance-2.0-text":
+			endpoint = "https://queue.fal.run/bytedance/seedance-2.0/text-to-video"
+			modelType = "text2video"
+		default:
+			return nil, fmt.Errorf("unsupported Seedance model: %s", modelName)
+		}
+
+		model, exists := GetModel(modelName, modelType)
+		if !exists {
+			return nil, fmt.Errorf("model not found: %s", modelName)
+		}
+		options, ok := model.Options.(*SeedanceOptions)
+		if !ok {
+			return nil, fmt.Errorf("invalid options type for model %s", modelName)
+		}
+
+		// Validate required fields
+		if r.Prompt == "" {
+			return nil, fmt.Errorf("prompt is required for %s", modelName)
+		}
+		if modelType == "image2video" && r.ImageURL == "" {
+			return nil, fmt.Errorf("image_url is required for %s", modelName)
+		}
+		if r.EndUserID == "" {
+			return nil, fmt.Errorf("end_user_id is required for %s (ByteDance tracking)", modelName)
+		}
+
+		// Validate options
+		opts := SeedanceOptions{
+			Duration:      r.Duration,
+			AspectRatio:   r.AspectRatio,
+			Resolution:    r.Resolution,
+			GenerateAudio: r.GenerateAudio,
+		}
+		if err := opts.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid options for %s: %v", modelName, err)
+		}
+
+		// Apply defaults from model options if not provided in request
+		if r.Duration == "" {
+			r.Duration = options.Duration
+		}
+		if r.AspectRatio == "" {
+			r.AspectRatio = options.AspectRatio
+		}
+		if r.Resolution == "" {
+			r.Resolution = options.Resolution
+		}
+		if r.GenerateAudio == nil {
+			r.GenerateAudio = options.GenerateAudio
+		}
+
+		// Build request body
+		reqBody = map[string]interface{}{
+			"prompt":       r.Prompt,
+			"duration":     r.Duration,
+			"aspect_ratio": r.AspectRatio,
+			"resolution":   r.Resolution,
+			"end_user_id":  r.EndUserID,
+		}
+		if r.GenerateAudio != nil {
+			reqBody["generate_audio"] = *r.GenerateAudio
+		}
+		if r.Seed != nil {
+			reqBody["seed"] = *r.Seed
+		}
+		// Image2video-specific fields
+		if modelType == "image2video" {
+			reqBody["image_url"] = r.ImageURL
+			if r.EndImageURL != "" {
+				reqBody["end_image_url"] = r.EndImageURL
+			}
+		}
+	case *SeedanceReferenceRequest:
+		modelName = "seedance-2.0-reference"
+		endpoint = "https://queue.fal.run/bytedance/seedance-2.0/reference-to-video"
+
+		model, exists := GetModel(modelName, "multi2video")
+		if !exists {
+			return nil, fmt.Errorf("model not found: %s", modelName)
+		}
+		options, ok := model.Options.(*SeedanceReferenceOptions)
+		if !ok {
+			return nil, fmt.Errorf("invalid options type for model %s", modelName)
+		}
+
+		// Validate required fields
+		if r.Prompt == "" {
+			return nil, fmt.Errorf("prompt is required for %s", modelName)
+		}
+		if r.EndUserID == "" {
+			return nil, fmt.Errorf("end_user_id is required for %s (ByteDance tracking)", modelName)
+		}
+
+		// Validate reference input constraints
+		totalRefs := len(r.ImageURLs) + len(r.VideoURLs) + len(r.AudioURLs)
+		if totalRefs == 0 {
+			return nil, fmt.Errorf("at least one reference input (image, video, or audio) is required for %s", modelName)
+		}
+		if totalRefs > 12 {
+			return nil, fmt.Errorf("total reference files must not exceed 12 (got %d)", totalRefs)
+		}
+		if len(r.ImageURLs) > 9 {
+			return nil, fmt.Errorf("max 9 reference images (got %d)", len(r.ImageURLs))
+		}
+		if len(r.VideoURLs) > 3 {
+			return nil, fmt.Errorf("max 3 reference videos (got %d)", len(r.VideoURLs))
+		}
+		if len(r.AudioURLs) > 3 {
+			return nil, fmt.Errorf("max 3 reference audio files (got %d)", len(r.AudioURLs))
+		}
+		if len(r.AudioURLs) > 0 && len(r.ImageURLs)+len(r.VideoURLs) == 0 {
+			return nil, fmt.Errorf("reference audio requires at least one reference image or video")
+		}
+
+		// Validate enum options
+		opts := SeedanceReferenceOptions{
+			Duration:      r.Duration,
+			AspectRatio:   r.AspectRatio,
+			Resolution:    r.Resolution,
+			GenerateAudio: r.GenerateAudio,
+		}
+		if err := opts.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid options for %s: %v", modelName, err)
+		}
+
+		// Apply defaults from model options if not provided in request
+		if r.Duration == "" {
+			r.Duration = options.Duration
+		}
+		if r.AspectRatio == "" {
+			r.AspectRatio = options.AspectRatio
+		}
+		if r.Resolution == "" {
+			r.Resolution = options.Resolution
+		}
+		if r.GenerateAudio == nil {
+			r.GenerateAudio = options.GenerateAudio
+		}
+
+		// Build request body
+		reqBody = map[string]interface{}{
+			"prompt":       r.Prompt,
+			"duration":     r.Duration,
+			"aspect_ratio": r.AspectRatio,
+			"resolution":   r.Resolution,
+			"end_user_id":  r.EndUserID,
+		}
+		if len(r.ImageURLs) > 0 {
+			reqBody["image_urls"] = r.ImageURLs
+		}
+		if len(r.VideoURLs) > 0 {
+			reqBody["video_urls"] = r.VideoURLs
+		}
+		if len(r.AudioURLs) > 0 {
+			reqBody["audio_urls"] = r.AudioURLs
+		}
+		if r.GenerateAudio != nil {
+			reqBody["generate_audio"] = *r.GenerateAudio
+		}
+		if r.Seed != nil {
+			reqBody["seed"] = *r.Seed
+		}
 	case *KlingVideoO3TextRequest:
 		modelName = r.BaseVideoRequest.Model
 		// Map model name to endpoint


### PR DESCRIPTION
Adds three ByteDance Seedance 2.0 variants at $0.35/s per-second pricing:

- seedance-2.0-image: image2video modality (fal base $0.3024/s at 720p)
- seedance-2.0-text: text2video modality (fal base $0.3034/s at 720p)
- seedance-2.0-reference: new multi2video modality accepting up to 9 reference images, 3 videos, and 3 audio files (12 files total)

Introduces the multi2video modality and !multi2video command for multi-modal reference-to-video generation. Enforces fal's per-modality limits and the "audio requires image or video" constraint locally for helpful error messages. Flat $0.35/s is profitable across both fal pricing tiers (~15% margin without video inputs, ~93% with).

Adds a new --seed flag supported across all video commands (extends parser.Parse return arity) and a new ParseMulti2Video parser method that handles --image1..9, --video1..3, --audio1..3 flags. The existing --audio toggle for generate_audio does not conflict because parser.go uses exact-string flag matching.

Auto-populates ByteDance's required end_user_id from the requester's zkidentity.ShortID (64-char hex), satisfying their copyright tracking requirement without exposing nicknames. The field is enforced as required at the fal dispatch layer for all seedance variants.

Shares SeedanceOptions/SeedanceRequest across the text and image variants (Kling v3 pattern), while multi2video uses a dedicated SeedanceReferenceRequest with ImageURLs/VideoURLs/AudioURLs slices.